### PR TITLE
Optimize main loop

### DIFF
--- a/covasim/model.py
+++ b/covasim/model.py
@@ -409,14 +409,11 @@ class Sim(cvbase.BaseSim):
                 else:
                     print(string)
 
+            not_susceptible = filter(lambda p: not p.susceptible, self.people.values())
+            n_susceptible = len(self.people)
             # Update each person
-            for person in self.people.values():
-
-                # Count susceptibles
-                if person.susceptible:
-                    n_susceptible += 1
-                    continue # Don't bother with the rest of the loop
-
+            for person in not_susceptible:
+                n_susceptible -= 1
                 # If exposed, check if the person becomes infectious or develops symptoms
                 if person.exposed:
                     n_exposed += 1


### PR DESCRIPTION
Quick optimization of main loop. Instead of iterating over susceptible people, filter them out and iterate over rest.

before
```
Total time: 6.63346 s
```

after
```
Total time: 4.81518 s
```