### PR TITLE
Fix webapp in docker, rename cova_webapp -> webapp

### DIFF
--- a/covasim/webapp/README.md
+++ b/covasim/webapp/README.md
@@ -56,7 +56,7 @@ server {
 For example:
 
 ```script
-cd covasim/covasim/cova_webapp
+cd covasim/covasim/webapp
 screen -S cova_app
 ./launch_gunicorn
 <Ctrl+D>

--- a/docker_nginx.conf
+++ b/docker_nginx.conf
@@ -1,7 +1,7 @@
 server {
   listen 80;
   location / {
-    root /app/covasim/cova_webapp;
+    root /app/covasim/webapp;
   }
   location /api {
     proxy_pass http://127.0.0.1:8097/;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:app]
-command=gunicorn --reload --workers=8 --bind=127.0.0.1:8097 covasim.cova_webapp.cova_app:flask_app
+command=gunicorn --reload --workers=8 --bind=127.0.0.1:8097 covasim.webapp.cova_app:flask_app
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stdout_logfile=/dev/stderr


### PR DESCRIPTION
When the webapp was changed to run from `cova_webapp` to `webapp`, Docker was not updated.

This meant that docker failed to run the webapp appropriately.

These updates fixed the problems locally for me.