### PR TITLE
Respect autoreload argument in cova_app.py

### DIFF
--- a/covasim/webapp/cova_app.py
+++ b/covasim/webapp/cova_app.py
@@ -512,4 +512,4 @@ if __name__ == "__main__":
     else:
         autoreload = 1
 
-    app.run(autoreload=True)
+    app.run(autoreload=autoreload)


### PR DESCRIPTION
Probably not THAT important since it only has an effect when using `launch_flask` in background mode (or invoking manually with `python3 ./cova_app.py <port> <autoreload>`).