### PR TITLE
Use matplotlib.pyplot instead of pylab

### DIFF
--- a/covasim/cruise_ship/parameters.py
+++ b/covasim/cruise_ship/parameters.py
@@ -4,6 +4,7 @@ Set the parameters for COVID-ABM.
 
 import os
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 from datetime import datetime
 
@@ -60,9 +61,9 @@ def get_age_sex(is_crew=False, min_age=18, max_age=99, crew_age=35, crew_std=5, 
 
     # Define age distribution for the crew and guests
     if is_crew:
-        age = np.normal(crew_age, crew_std)
+        age = np.random.normal(crew_age, crew_std)
     else:
-        age = np.normal(guest_age, guest_std)
+        age = np.random.normal(guest_age, guest_std)
 
     # Normalize
     age = np.median([min_age, age, max_age])

--- a/covasim/cruise_ship/parameters.py
+++ b/covasim/cruise_ship/parameters.py
@@ -3,7 +3,7 @@ Set the parameters for COVID-ABM.
 '''
 
 import os
-import pylab as pl
+import matplotlib.pyplot as plt
 import pandas as pd
 from datetime import datetime
 
@@ -56,16 +56,16 @@ def get_age_sex(is_crew=False, min_age=18, max_age=99, crew_age=35, crew_std=5, 
     '''
 
     # Define female (0) or male (1) -- evenly distributed
-    sex = pl.randint(2)
+    sex = np.random.randint(2)
 
     # Define age distribution for the crew and guests
     if is_crew:
-        age = pl.normal(crew_age, crew_std)
+        age = np.normal(crew_age, crew_std)
     else:
-        age = pl.normal(guest_age, guest_std)
+        age = np.normal(guest_age, guest_std)
 
     # Normalize
-    age = pl.median([min_age, age, max_age])
+    age = np.median([min_age, age, max_age])
 
     return age, sex
 
@@ -91,6 +91,3 @@ def load_data(filename=None):
     data = raw_data[cols]
 
     return data
-
-
-

--- a/covasim/interventions.py
+++ b/covasim/interventions.py
@@ -1,5 +1,5 @@
 import covasim as cv
-import pylab as pl
+import matplotlib.pyplot as plt
 import numpy as np
 import sciris as sc
 
@@ -229,7 +229,7 @@ class change_beta(Intervention):
         ''' Plot vertical lines for when changes in beta '''
         ylims = ax.get_ylim()
         for day in self.days:
-            pl.plot([day]*2, ylims, '--')
+            plt.plot([day]*2, ylims, '--')
         return
 
 
@@ -269,7 +269,7 @@ class test_num(Intervention):
             return
 
         # If there are no tests today, abort early
-        if not (n_tests and pl.isfinite(n_tests)):
+        if not (n_tests and np.isfinite(n_tests)):
             return
 
         test_probs = np.ones(sim.n)

--- a/covasim/run.py
+++ b/covasim/run.py
@@ -278,7 +278,7 @@ class Scenarios(cvbase.ParsObj):
                 # Optionally reset tick marks (useful for e.g. plotting weeks/months)
                 if interval:
                     xmin,xmax = ax.get_xlim()
-                    ax.set_xticks(plt.arange(xmin, xmax+1, interval))
+                    ax.set_xticks(np.arange(xmin, xmax+1, interval))
 
                 # Set xticks as dates
                 if as_dates:

--- a/covasim/run.py
+++ b/covasim/run.py
@@ -4,7 +4,7 @@ Functions for running multiple Covasim runs.
 
 #%% Imports
 import numpy as np
-import pylab as pl
+import matplotlib.pyplot as plt
 import sciris as sc
 from . import base as cvbase
 from . import sim as cvsim
@@ -166,7 +166,7 @@ class Scenarios(cvbase.ParsObj):
 
             scenraw = {}
             for reskey in reskeys:
-                scenraw[reskey] = pl.zeros((self.npts, len(scen_sims)))
+                scenraw[reskey] = np.zeros((self.npts, len(scen_sims)))
                 for s,sim in enumerate(scen_sims):
                     scenraw[reskey][:,s] = sim.results[reskey].values
 
@@ -175,9 +175,9 @@ class Scenarios(cvbase.ParsObj):
             scenres.low = {}
             scenres.high = {}
             for reskey in reskeys:
-                scenres.best[reskey] = pl.mean(scenraw[reskey], axis=1) # Changed from median to mean for smoother plots
-                scenres.low[reskey]  = pl.quantile(scenraw[reskey], q=self['quantiles']['low'], axis=1)
-                scenres.high[reskey] = pl.quantile(scenraw[reskey], q=self['quantiles']['high'], axis=1)
+                scenres.best[reskey] = np.mean(scenraw[reskey], axis=1) # Changed from median to mean for smoother plots
+                scenres.low[reskey]  = np.quantile(scenraw[reskey], q=self['quantiles']['low'], axis=1)
+                scenres.high[reskey] = np.quantile(scenraw[reskey], q=self['quantiles']['high'], axis=1)
 
             for reskey in reskeys:
                 self.allres[reskey][scenkey]['name'] = scenname
@@ -211,10 +211,10 @@ class Scenarios(cvbase.ParsObj):
             to_plot     (dict): Dict of results to plot; see default_scen_plots for structure
             do_save     (bool): Whether or not to save the figure
             fig_path    (str):  Path to save the figure
-            fig_args    (dict): Dictionary of kwargs to be passed to pl.figure()
-            plot_args   (dict): Dictionary of kwargs to be passed to pl.plot()
-            axis_args   (dict): Dictionary of kwargs to be passed to pl.subplots_adjust()
-            fill_args   (dict): Dictionary of kwargs to be passed to pl.fill_between()
+            fig_args    (dict): Dictionary of kwargs to be passed to plt.figure()
+            plot_args   (dict): Dictionary of kwargs to be passed to plt.plot()
+            axis_args   (dict): Dictionary of kwargs to be passed to plt.subplots_adjust()
+            fill_args   (dict): Dictionary of kwargs to be passed to plt.fill_between()
             as_dates    (bool): Whether to plot the x-axis as dates or time points
             interval    (int):  Interval between tick marks
             dateformat  (str):  Date string format, e.g. '%B %d'
@@ -247,38 +247,38 @@ class Scenarios(cvbase.ParsObj):
         if sep_figs:
             figs = []
         else:
-            fig = pl.figure(**fig_args)
-        pl.subplots_adjust(**axis_args)
-        pl.rcParams['font.size'] = font_size
+            fig = plt.figure(**fig_args)
+        plt.subplots_adjust(**axis_args)
+        plt.rcParams['font.size'] = font_size
         if font_family:
-            pl.rcParams['font.family'] = font_family
+            plt.rcParams['font.family'] = font_family
 
         # %% Plotting
         for rk,reskey,title in to_plot.enumitems():
             if sep_figs:
-                figs.append(pl.figure(**fig_args))
-                ax = pl.subplot(111)
+                figs.append(plt.figure(**fig_args))
+                ax = plt.subplot(111)
             else:
-                ax = pl.subplot(len(to_plot), 1, rk + 1)
+                ax = plt.subplot(len(to_plot), 1, rk + 1)
 
             resdata = self.allres[reskey]
 
             for scenkey, scendata in resdata.items():
 
-                pl.fill_between(self.tvec, scendata.low, scendata.high, **fill_args)
-                pl.plot(self.tvec, scendata.best, label=scendata.name, **plot_args)
-                pl.title(title)
+                plt.fill_between(self.tvec, scendata.low, scendata.high, **fill_args)
+                plt.plot(self.tvec, scendata.best, label=scendata.name, **plot_args)
+                plt.title(title)
                 if rk == 0:
-                    pl.legend(loc='best')
+                    plt.legend(loc='best')
 
-                pl.grid(grid)
+                plt.grid(grid)
                 if commaticks:
                     sc.commaticks()
 
                 # Optionally reset tick marks (useful for e.g. plotting weeks/months)
                 if interval:
                     xmin,xmax = ax.get_xlim()
-                    ax.set_xticks(pl.arange(xmin, xmax+1, interval))
+                    ax.set_xticks(plt.arange(xmin, xmax+1, interval))
 
                 # Set xticks as dates
                 if as_dates:
@@ -291,12 +291,12 @@ class Scenarios(cvbase.ParsObj):
             if fig_path is None: # No figpath provided - see whether do_save is a figpath
                 fig_path = 'covasim_scenarios.png' # Just give it a default name
             fig_path = sc.makefilepath(fig_path) # Ensure it's valid, including creating the folder
-            pl.savefig(fig_path)
+            plt.savefig(fig_path)
 
         if do_show:
-            pl.show()
+            plt.show()
         else:
-            pl.close(fig)
+            plt.close(fig)
 
         return fig
 

--- a/covasim/utils.py
+++ b/covasim/utils.py
@@ -5,7 +5,7 @@ Utilities for running the COVID-ABM
 import numba  as nb # For faster computations
 import numpy  as np # For numerics
 import pandas as pd # Used for pd.unique() (better than np.unique())
-import pylab  as pl # Used by fixaxis()
+import matplotlib.pyplot as plt # Used by fixaxis()
 import sciris as sc # Used by fixaxis()
 import scipy.stats as sps # Used by poisson_test()
 
@@ -201,9 +201,9 @@ def choose_weighted(probs, n, overshoot=1.5, eps=1e-6, max_tries=10, normalize=F
 def fixaxis(sim, useSI=True, boxoff=False):
     ''' Make the plotting more consistent -- add a legend and ensure the axes start at 0 '''
     delta = 0.5
-    pl.legend() # Add legend
+    plt.legend() # Add legend
     sc.setylim() # Rescale y to start at 0
-    pl.xlim((0, sim['n_days']+delta))
+    plt.xlim((0, sim['n_days']+delta))
     if boxoff:
         sc.boxoff() # Turn off top and right lines
     return

--- a/tests/dev_test_synthpops.py
+++ b/tests/dev_test_synthpops.py
@@ -4,7 +4,7 @@ Test different population options
 
 #%% Imports and settings
 import pytest
-import pylab as pl
+import matplotlib.pyplot as plt
 import sciris as sc
 import covasim as cova
 try:
@@ -53,7 +53,7 @@ def test_pop_options(doplot=False): # If being run via pytest, turn off
         for key,sim in sims.items():
             sim.plot()
             try:
-                pl.gcf().axes[0].set_title(f'Counts: {key}')
+                plt.gcf().axes[0].set_title(f'Counts: {key}')
             except:
                 pass
 
@@ -100,7 +100,7 @@ def test_interventions(doplot=False): # If being run via pytest, turn off
     if doplot:
         for key,sim in sims.items():
             sim.plot()
-            pl.gcf().axes[0].set_title(f'Counts: {key}')
+            plt.gcf().axes[0].set_title(f'Counts: {key}')
 
     return sims
 

--- a/tests/test_age_structure.py
+++ b/tests/test_age_structure.py
@@ -3,7 +3,7 @@ Simple example usage for the Covid-19 agent-based model
 '''
 
 #%% Imports and settings
-import pylab as pl
+import matplotlib.pyplot as plt
 import sciris as sc
 import covasim as cova
 
@@ -44,17 +44,17 @@ def test_age_structure(doplot=False): # If being run via pytest, turn off
     #         sim.plot()
 
     #     # Plot ages
-    #     pl.figure(figsize=figsize)
+    #     plt.figure(figsize=figsize)
     #     for a,key,age in ages.enumitems():
     #         if key == 'without':
     #             title = f'Normally-distributed age distribution'
     #         elif key == 'withdata':
     #             title = f'Age distribution based on Seattle census data'
-    #         pl.subplot(2,1,a+1)
-    #         pl.hist(ages[a], nbins)
-    #         pl.title(title)
-    #         pl.xlabel('Age')
-    #         pl.ylabel('Number of people')
+    #         plt.subplot(2,1,a+1)
+    #         plt.hist(ages[a], nbins)
+    #         plt.title(title)
+    #         plt.xlabel('Age')
+    #         plt.ylabel('Number of people')
 
     # return sims, ages
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -5,6 +5,7 @@ Test that the parameters and data files are being created correctly.
 #%% Imports
 import pytest
 import matplotlib.pyplot as plt
+import numpy as np
 import sciris as sc
 import covasim.cruise_ship as cova # NOTE: this is the only tests script that doesn't use base
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -4,7 +4,7 @@ Test that the parameters and data files are being created correctly.
 
 #%% Imports
 import pytest
-import pylab as pl
+import matplotlib.pyplot as plt
 import sciris as sc
 import covasim.cruise_ship as cova # NOTE: this is the only tests script that doesn't use base
 
@@ -39,7 +39,7 @@ def test_age_sex(do_plot=False):
         ages['crew'].append(age)
 
     for key in keys:
-        ages[key] = pl.array(ages[key])
+        ages[key] = np.array(ages[key])
 
     age_bins = [60, 80, 90]
     reported = [2130, 226, 11]
@@ -59,14 +59,14 @@ def test_age_sex(do_plot=False):
     >{age_bins[2]} = {simulated[2]}''')
 
     if do_plot:
-        pl.figure(figsize=(18,12))
+        plt.figure(figsize=(18,12))
         for i,key in enumerate(keys):
-            pl.subplot(2,1,i+1)
-            pl.hist(ages[key], bins=30)
-            pl.xlim([0,100])
-            pl.title(f'Age distribution for {key}')
-            pl.xlabel('Age')
-            pl.ylabel('Count')
+            plt.subplot(2,1,i+1)
+            plt.hist(ages[key], bins=30)
+            plt.xlim([0,100])
+            plt.title(f'Age distribution for {key}')
+            plt.xlabel('Age')
+            plt.ylabel('Count')
 
     return ages
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ Tests of the utilies for the model.
 import pytest
 import numpy as np
 import numba as nb
-import pylab as pl
+import matplotlib.pyplot as plt
 import sciris as sc
 import covasim as cova
 
@@ -89,7 +89,7 @@ def test_samples(doplot=False):
         ]
 
     if doplot:
-        pl.figure(figsize=(20,14))
+        plt.figure(figsize=(20,14))
 
     # Run the samples
     nchoices = len(choices)
@@ -108,9 +108,9 @@ def test_samples(doplot=False):
         results[choice] = cova.sample(dist=choice, par1=par1, par2=par2, size=n)
 
         if doplot:
-            pl.subplot(nsqr, nsqr, c+1)
-            pl.hist(x=results[choice], bins=nbins)
-            pl.title(f'dist={choice}, par1={par1}, par2={par2}')
+            plt.subplot(nsqr, nsqr, c+1)
+            plt.hist(x=results[choice], bins=nbins)
+            plt.title(f'dist={choice}, par1={par1}, par2={par2}')
 
     with pytest.raises(NotImplementedError):
         cova.sample(dist='not_found')


### PR DESCRIPTION
The official [documentation for matplotlib][0] says:

> `pylab` combines pyplot with numpy into a single namespace. This is convenient
> for interactive work, but for programming it is recommended that the namespaces
> be kept separate, e.g.:
>
> ```
> import numpy as np
> import matplotlib.pyplot as plt
>
> x = np.arange(0, 5, 0.1);
> y = np.sin(x)
> plt.plot(x, y)
> ```

Personally, as someone who hasn't touched matplotlib in 5 years, this separation makes it a bit easier to understand what is going on :)

[0]: https://matplotlib.org/api/pyplot_api.html