### PR TITLE
Cache python packages in GH Actions

### DIFF
--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -14,6 +14,10 @@ jobs:
       - name: Set repo owner env variable
         shell: python
         run: print("::set-env name=GITHUB_OWNER::{}".format('${{github.repository}}'.split('/')[0]))
+      - name: Set PYTHONPATH
+        run: |
+          mkdir -p $HOME/.cache/site-packages
+          echo "::set-env name=PYTHONPATH::$HOME/.cache/site-packages"
       - name: Checkout sources
         uses: actions/checkout@v1
       # - name: Checkout synthpops
@@ -26,8 +30,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+      - name: Cache Packages
+        id: cache-packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/ # This path is specific to Ubuntu
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: packages-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            packages-${{ runner.os }}-${{ matrix.python-version }}-
+      # Pip install first will make setup.py much faster and the cache will make pip install fast
       - name: Install Covasim
-        run: python setup.py develop
+        run: |
+          python setup.py develop --install-dir ~/.cache/site-packages
       # - name: Install synthpops
       #   working-directory: ./synthpops
       #   run: python setup.py develop


### PR DESCRIPTION
What this does
---
- This caches the packages from between builds, it is hashed against `requirements.txt`
- This installed pytest and setuptools installs to `~/.cache/site-packages` for easy caching
- Saves time in CI. *We will not see the benefits on this PR as the cache has just been set*

What gains do we get here?
---
- About 40-50 seconds! (Keep in mind this is _after_ the first cache has been set)
- Latest master ran in 2m41s to 2m47s with `install covasim` taking about 53s: <img width="683" alt="image" src="https://user-images.githubusercontent.com/3074765/78323081-c151b100-753e-11ea-8c33-8c86d588b85d.png">
- With the cache, I ran in 2mXs to 2mXs with `install covasim` taking about 10s. The test step was also cut down by about 6s as pytest is also cached : <img width="635" alt="image" src="https://user-images.githubusercontent.com/3074765/78324534-f102b800-7542-11ea-9998-47c4d762d2df.png">


Other Thoughts
---
- It seems that our `setuptools` script is implicitly using `easy_install`, which is deprecated, so we might want to look into doing a `pip` install instead?
- We may want to add versions to our `requirements.txt` as the current setup is implicitly locking us to a version with the current cache