### PR TITLE
Use `pip install -e` instead of `python setup.py develop`

### DIFF
--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -14,10 +14,6 @@ jobs:
       - name: Set repo owner env variable
         shell: python
         run: print("::set-env name=GITHUB_OWNER::{}".format('${{github.repository}}'.split('/')[0]))
-      - name: Set PYTHONPATH
-        run: |
-          mkdir -p $HOME/.cache/site-packages
-          echo "::set-env name=PYTHONPATH::$HOME/.cache/site-packages"
       - name: Checkout sources
         uses: actions/checkout@v1
       # - name: Checkout synthpops
@@ -34,22 +30,21 @@ jobs:
         id: cache-packages
         uses: actions/cache@v1
         with:
-          path: ~/.cache/ # This path is specific to Ubuntu
+          path: ~/.cache/pip # This path is specific to Ubuntu
           # Look to see if there is a cache hit for the corresponding requirements file
-          key: packages-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          key: packages-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('setup.py') }}
           restore-keys: |
             packages-${{ runner.os }}-${{ matrix.python-version }}-
       # Pip install first will make setup.py much faster and the cache will make pip install fast
       - name: Install Covasim
         run: |
-          python setup.py develop --install-dir ~/.cache/site-packages
+          pip install -e ".[test]"
       # - name: Install synthpops
       #   working-directory: ./synthpops
       #   run: python setup.py develop
       - name: Run tests
         working-directory: ./tests
         run: |
-          pip install pytest
           # pytest test*.py unittests/test*.py --junitxml=test-results.xml # Run actual tests
           pytest test*.py --junitxml=test-results.xml # Run actual tests
       - name: Run examples

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -26,17 +26,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - name: Cache Packages
-        id: cache-packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip # This path is specific to Ubuntu
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: packages-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            packages-${{ runner.os }}-${{ matrix.python-version }}-
       # Pip install first will make setup.py much faster and the cache will make pip install fast
       - name: Install Covasim
+        # `pip install -e` doesn't work together with --target, and since most of the `pip
+        # install` time is spent in setting up packages (and not downloading them), we
+        # don't use caching.
         run: |
           pip install -e ".[test]"
       # - name: Install synthpops

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ more information, see documentation for [venv](https://docs.python.org/3/tutoria
 
 ## Quick start guide
 
-Install with `pip install covasim`. If everything is working, the following Python commands should bring up a plot:
+Install with `pip install covasim[webapp]`. If everything is working, the following Python commands should bring up a plot:
 
 ```python
 import covasim as cv
@@ -24,8 +24,7 @@ sim.run()
 sim.plot()
 ```
 
-
-## Detailed installation instructions
+## Development setup instructions
 
 1.  Clone a copy of the repository. If you intend to make changes to the code,
     we recommend that you fork it first.
@@ -37,16 +36,16 @@ sim.plot()
 
     *   To install with webapp support (recommended):
 
-        `python setup.py develop`
+        `pip install -e ".[test, webapp]"`
 
-    *   To install as a standalone Python model without webapp support:
+    *   To install without webapp support:
 
-        `python setup.py develop nowebapp`
+        `pip install -e ".[test]`
 
     *   To install Covasim and optional dependencies (be aware this may fail
         since it relies on private packages), enter:
 
-        `python setup.py develop full`
+        `pip install -e ".[test, webapp, full]"`
 
     The module should then be importable via `import covasim`.
 

--- a/setup.py
+++ b/setup.py
@@ -15,24 +15,18 @@ from setuptools import setup, find_packages
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
-if 'nowebapp' in sys.argv:
-    print('Performing standalone installation -- running as a web application will not work')
-    sys.argv.remove('nowebapp')
-    webapp_reqs = [
+extras_require = {
+    'webapp': [
         'scirisweb',
         'gunicorn',
-        'plotly_express'
-    ]
-    requirements = [req for req in requirements if req not in webapp_reqs]
-
-if 'full' in sys.argv:
-    print('Performing full installation, including optional dependencies')
-    sys.argv.remove('full')
-    full_reqs = [
+        'plotly_express',
+    ],
+    'test': ['pytest'],
+    'full': [
         'synthpops',
-        'parestlib'
-    ]
-    requirements.extend(full_reqs)
+        'parestlib',
+    ],
+}
 
 # Get version
 cwd = os.path.abspath(os.path.dirname(__file__))
@@ -68,5 +62,6 @@ setup(
     classifiers=CLASSIFIERS,
     packages=find_packages(),
     include_package_data=True,
-    install_requires=requirements
+    install_requires=requirements,
+    extras_require=extras_require,
 )


### PR DESCRIPTION
This uses [pip "editable" installs](https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs) which is a more modern approach than using `python setup.py develop`.

I couldn't really find any "hard facts" to support this argument, but I can reference that this is what popular projects like [flask] and [django] recommends for installing their code in a development version.

Furthermore, as @jules2689 pointed out, using pip instead of setuptools with easy_install can also enable hash checking in the future if that is something we would like to do: https://pip.pypa.io/en/stable/reference/pip_install/#require-hashes

[flask]: https://github.com/pallets/flask/blob/master/CONTRIBUTING.rst#first-time-setup
[django]: https://docs.djangoproject.com/en/3.0/topics/install/#installing-the-development-version