### PR TITLE
Add Data Scraper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ covasim/cova_seattle/capacity_analysis
 covasim/cova_seattle/school_analysis
 covasim/cova_seattle/seattle_analysis
 results/
-
+data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/data_loaders/README.md
+++ b/data_loaders/README.md
@@ -51,7 +51,7 @@ The following columns are present in the data:
 
 As of April 4, 2020, There are apparently 3280 data sets.
 
-## 1. European Centre for Disease Prevention and Control 
+## 2. European Centre for Disease Prevention and Control 
 
 
 To quote the [European Centre for Disease Prevention and Control ](https://www.ecdc.europa.eu/en/geographical-distribution-2019-ncov-cases) web page,
@@ -82,3 +82,56 @@ The following columns are present in the data:
 - `day`: Number of days since first reporting
 - `new_positives`: New positives on this date
 - `new_death`: Number of deaths on this date
+
+## 3. The COVID Tracking Project
+
+The COVID Tracking Project "obtains, organizes, and publishes high-quality data required to understand and respond to the COVID-19 outbreak in the United States." The project website is https://covidtracking.com
+
+
+We transform this data for use in the Covasim parameter format. It is stored
+in CSV-format. 
+
+### Updating
+
+To update the COVID Tracking Project data,
+
+```bash
+python data_loaders/load_covid_tracking_project_data.py
+```
+
+This will create a file `covid-tracking-project-data.csv` in the data directory.
+
+This adds data from each of the US states and territories, as well as for the whole of the United States. The following fields are saved:
+
+- `date`
+- `positive`
+- `negative`
+- `pending`
+- `hospitalizedCurrently`
+- `hospitalizedCumulative`
+- `inIcuCurrently`
+- `inIcuCumulative`
+- `onVentilatorCurrently`
+- `onVentilatorCumulative`
+- `recovered`
+- `hash`
+- `dateChecked`
+- `death`
+- `hospitalized`
+- `total`
+- `totalTestResults`
+- `posNeg`
+- `fips`
+- `hospitalizedIncrease`
+- `negativeIncrease`
+- `name`
+- `day`
+- `new_positives`
+- `new_negatives`
+- `new_tests`
+- `new_death`
+- `new_icu`
+- `new_vent`
+
+More details at: https://covidtracking.com/api The `new_` variables are per-day
+changes in the values, in parameter.py format.

--- a/data_loaders/README.md
+++ b/data_loaders/README.md
@@ -71,7 +71,7 @@ python data_loaders/load_ecdp_data.py
 
 This will create a file `ecdp_data.csv` in the data directory.
 
-This adds data from 204 countries and territories, including Africa, Asia, the Americas, Europe, and Oceania. More details at: https://www.ecdc.europa.eu/en/geographical-distribution-2019-ncov-cases
+This adds data from 204 countries and territories (as of April 5, 2020), including Africa, Asia, the Americas, Europe, and Oceania. More details at: https://www.ecdc.europa.eu/en/geographical-distribution-2019-ncov-cases
 
 The following columns are present in the data:
 

--- a/data_loaders/README.md
+++ b/data_loaders/README.md
@@ -1,0 +1,52 @@
+# Data Loaders
+
+## 1. Corona Data Scraper
+
+
+To quote the [Corona Data Scraper](https://coronadatascraper.com) web page,
+
+> Corona Data Scraper pulls COVID-19 Coronavirus case data from verified sources, finds the corresponding GeoJSON features, and adds population data.
+
+We transform this data for use in the Covasim parameter format. It is stored
+in CSV-format. 
+
+### Updating
+
+To update the  Corona Data Scraper data,
+
+```bash
+python data_loaders/load_corona_data_scraper_data.py 
+```
+
+This will create a file `corona_data_scraper.csv` in the data directory.
+
+### Data dictionary
+
+The following columns are present in the data:
+
+- `name`: Apparently, a unique name for the data set
+- `level`: level of the data (country, state, county, city)
+- `city`: The city name
+- `county`: The county or parish
+- `state`: The state, province, or region
+- `country`: [ ISO 3166-1 alpha-3 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)
+- `population`: The estimated population of the location
+- `lat`: latitude
+- `long`: longitude
+- `url`: Data source
+- aggregate
+- `tz`: Time zone
+- `recovered`: Cumulative number recovered (as of date)
+- `active`: Cumulative number active (as of date)
+- `growthFactor`:
+- `date`: Date in yyyy-MM-dd text format
+- `day`: Number of days since first reporting
+- `positives`: Cumulative number of positive cases (as of date)
+- `death`: Cumulative number of deaths (as of date)
+- `tests`: Cumulative number of tests (as of date)
+- `new_positives`: New positives on this date
+- `new_active`: New active cases on this date
+- `new_death`: Number of deaths on this date
+- `new_tests`: New tests on this date
+
+As of April 4, 2020, There are apparently 3280 data sets.

--- a/data_loaders/README.md
+++ b/data_loaders/README.md
@@ -50,3 +50,23 @@ The following columns are present in the data:
 - `new_tests`: New tests on this date
 
 As of April 4, 2020, There are apparently 3280 data sets.
+
+## 1. European Centre for Disease Prevention and Control 
+
+
+To quote the [European Centre for Disease Prevention and Control ](https://www.ecdc.europa.eu/en/geographical-distribution-2019-ncov-cases) web page,
+
+> Since the beginning of the coronavirus pandemic, ECDC’s Epidemic Intelligence team has been collecting the number of COVID-19 cases and deaths, based on reports from health authorities worldwide. This comprehensive and systematic process is carried out on a daily basis. To insure the accuracy and reliability of the data, this process is being constantly refined. This helps to monitor and interpret the dynamics of the COVID-19 pandemic not only in the European Union (EU), the European Economic Area (EEA), but also worldwide.
+
+We transform this data for use in the Covasim parameter format. It is stored
+in CSV-format. 
+
+### Updating
+
+To update the  Corona Data Scraper data,
+
+```bash
+python data_loaders/load_ecdp_data.py 
+```
+
+This will create a file `ecdp_data.csv` in the data directory.

--- a/data_loaders/README.md
+++ b/data_loaders/README.md
@@ -70,3 +70,15 @@ python data_loaders/load_ecdp_data.py
 ```
 
 This will create a file `ecdp_data.csv` in the data directory.
+
+This adds data from 204 countries and territories, including Africa, Asia, the Americas, Europe, and Oceania. More details at: https://www.ecdc.europa.eu/en/geographical-distribution-2019-ncov-cases
+
+The following columns are present in the data:
+
+- `countriesAndTerritories`: Unique country or territory name
+- `geoId`: Geo ID of same
+- `countryterritoryCode`: ISO 3-letter code?
+- `date`: Date in yyyy-MM-dd text format
+- `day`: Number of days since first reporting
+- `new_positives`: New positives on this date
+- `new_death`: Number of deaths on this date

--- a/data_loaders/load_corona_data_scraper_data.py
+++ b/data_loaders/load_corona_data_scraper_data.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import os.path
+import sys
+import logging
+
+log = logging.getLogger("Corona Data Scraper Data Loader")
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+
+# Read in the Corona Data Scraper Data into a dataframe.
+
+log.info("Loading timeseries data from coronadatascraper.com")
+cds = pd.read_csv("https://coronadatascraper.com/timeseries.csv")
+log.info(f"Loaded {len(cds)} records; now transforming data")
+
+# Just to be safe, let's sort by name and date. Probably not 
+# necessary but better safe than sorry!.
+cds = cds.sort_values(['name', 'date'])
+
+# Each data set has a unique name. Let's create groups.
+g = cds.groupby('name')
+
+# The parameter 'day' is the number of days since the first 
+# day of data collection for the group.
+cds['day'] = g['date'].transform(lambda x: (pd.to_datetime(
+    x) - min(pd.to_datetime(x)))).apply(lambda x: x.days)
+
+# We'll 'rename' some of the columns to be consistent
+# with the parameters file.
+
+cds['positives'] = cds.cases
+cds['death'] = cds.deaths
+cds['tests'] = cds.tested
+cds.drop(['cases', 'deaths', 'tested'], inplace=True, axis=1)
+
+# The Corona Data Scraper Data contains cumulative totals
+# for each group. We want _new_ amounts per the previous
+# (reporting) day. So we 'shift' or lag the data by
+# one.
+cds["positives_lagged"] = g.positives.shift(1)
+cds["death_lagged"] = g.death.shift(1)
+cds['active_lagged'] = g.active.shift(1)
+cds['tests_lagged'] = g.tests.shift(1)
+
+# And subtract the current number from the previous reported
+# day, filling in the first number with data from the first
+# row of the group. Other N/As will remain N/A.
+cds['new_positives'] = cds.positives.sub(
+    cds.positives_lagged).fillna(cds.positives)
+cds['new_active'] = cds.active.sub(cds.active_lagged).fillna(cds.active)
+cds['new_death'] = cds.death.sub(cds.death_lagged).fillna(cds.death)
+cds['new_tests'] = cds.tests.sub(cds.tests_lagged).fillna(cds.tests)
+
+# We'll drop the unneeded lag data.
+cds.drop(['positives_lagged', 'death_lagged', 'active_lagged', 'tests_lagged'], inplace=True, axis=1)
+
+# And save it to the data directory.
+
+here = os.path.abspath(os.path.dirname(__file__))
+data_home = os.path.join(here, "../data")
+if not os.path.exists(data_home):
+    log.info(f"Creating data directory {data_home}")
+    os.makedirs(data_home)
+path = os.path.join(data_home, "corona_data_scraper.csv")
+log.info(f"Saving to {path}")
+cds.to_csv(path)
+log.info(f"Script complete")

--- a/data_loaders/load_covid_tracking_project_data.py
+++ b/data_loaders/load_covid_tracking_project_data.py
@@ -1,0 +1,77 @@
+import pandas as pd
+import os.path
+import sys
+import logging
+import datetime as dt
+
+log = logging.getLogger("Covid Tracking Project Loader")
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+
+# Read in the Corona Data Scraper Data into a dataframe.
+
+log.info("Loading states timeseries data from covidtracking.com")
+df_states = pd.read_csv("https://covidtracking.com/api/v1/states/daily.csv")
+df_states['name'] = df_states.state
+df_states.drop(['state'], inplace=True, axis=1)
+log.info("Loading US timeseries data from covidtracking.com")
+df_us = pd.read_csv("https://covidtracking.com/api/v1/us/daily.csv")
+df_us['name'] = 'US'
+df_us.drop(['states'], inplace=True, axis=1)
+
+# Put them together
+
+df = pd.concat([df_states, df_us], ignore_index=True, sort=False)
+
+# Convert integer date to a datetime date
+
+
+def covid_tracking_date_to_date(d):
+    return dt.date((d // 10000), ((d % 1000) // 100), (d % 1000) % 100)
+
+
+df.date = df.date.apply(covid_tracking_date_to_date)
+
+# Sort by name and date.
+df = df.sort_values(['name', 'date'])
+
+# Each data set has a unique name. Let's create groups.
+g = df.groupby('name')
+
+# The parameter 'day' is the number of days since the first
+# day of data collection for the group.
+df['day'] = g['date'].transform(lambda x: (x - min(x))).apply(lambda x: x.days)
+
+# We'll 'rename' some of the columns to be consistent
+# with the parameters file.
+
+df['new_positives'] = df.positiveIncrease
+df['new_negatives'] = df.negativeIncrease
+df['new_tests'] = df.totalTestResultsIncrease
+df['new_death'] = df.deathIncrease
+
+df.drop(['positiveIncrease', 'positiveIncrease',
+         'totalTestResultsIncrease', 'deathIncrease'], inplace=True, axis=1)
+
+# The COVID Project contains cumulative totals
+# for ICU and ventilator data. We get the daily
+# adjusted values and drop the no longer needed
+# columns
+
+df['icu_lagged'] = g.inIcuCurrently.shift(1)
+df['vent_lagged'] = g.onVentilatorCurrently.shift(1)
+df['new_icu'] = df.inIcuCurrently.sub(df.icu_lagged).fillna(df.inIcuCurrently)
+df['new_vent'] = df.onVentilatorCurrently.sub(
+    df.vent_lagged).fillna(df.onVentilatorCurrently)
+df.drop(['icu_lagged', 'vent_lagged'], inplace=True, axis=1)
+
+# And save it to the data directory.
+
+here = os.path.abspath(os.path.dirname(__file__))
+data_home = os.path.join(here, "../data")
+if not os.path.exists(data_home):
+    log.info(f"Creating data directory {data_home}")
+    os.makedirs(data_home)
+path = os.path.join(data_home, "covid-tracking-project-data.csv")
+log.info(f"Saving to {path}")
+df.to_csv(path)
+log.info(f"Script complete")

--- a/data_loaders/load_ecdc_data.py
+++ b/data_loaders/load_ecdc_data.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import os.path
+import sys
+import logging
+
+log = logging.getLogger(
+    "ECDC Data Loader")
+logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
+
+# Read in the European Centre for Disease Prevention and Control Data into a dataframe.
+
+log.info("Loading European Centre for Disease Prevention and Control timeseries data from opendata.ecdc.europa.eu")
+df = pd.read_csv(
+    "https://opendata.ecdc.europa.eu/covid19/casedistribution/csv")
+log.info(f"Loaded {len(df)} records; now transforming data")
+
+# Use internal data to create dates; only keep `date` column
+df['date'] = pd.to_datetime(df[['year', 'month', 'day']])
+df.drop(['dateRep', 'day', 'month', 'year'], inplace=True, axis=1)
+
+# Just to be safe, let's sort by name and date. Probably not 
+# necessary but better safe than sorry!.
+df = df.sort_values(['countriesAndTerritories', 'date'])
+
+# Each data set has a unique name. Let's create groups.
+g = df.groupby('countriesAndTerritories')
+
+# The parameter 'day' is the number of days since the first 
+# day of data collection for the group.
+df['day'] = g['date'].transform(lambda x: (x - min(x))).apply(lambda x: x.days)
+
+
+# We'll 'rename' some of the columns to be consistent
+# with the parameters file.
+
+df['new_positives'] = df.cases
+df['new_death'] = df.deaths
+df['population'] = df.popData2018
+df.drop(['cases', 'deaths', 'popData2018'], inplace=True, axis=1)
+
+
+# And save it to the data directory.
+
+here = os.path.abspath(os.path.dirname(__file__))
+data_home = os.path.join(here, "../data")
+if not os.path.exists(data_home):
+    log.info(f"Creating data directory {data_home}")
+    os.makedirs(data_home)
+path = os.path.join(data_home, "ecdc.csv")
+log.info(f"Saving to {path}")
+df.to_csv(path)
+log.info(f"Script complete")

--- a/data_loaders/load_ecdp_data.py
+++ b/data_loaders/load_ecdp_data.py
@@ -4,7 +4,7 @@ import sys
 import logging
 
 log = logging.getLogger(
-    "ECDC Data Loader")
+    "ECDP Data Loader")
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 
 # Read in the European Centre for Disease Prevention and Control Data into a dataframe.
@@ -46,7 +46,7 @@ data_home = os.path.join(here, "../data")
 if not os.path.exists(data_home):
     log.info(f"Creating data directory {data_home}")
     os.makedirs(data_home)
-path = os.path.join(data_home, "ecdc.csv")
+path = os.path.join(data_home, "ecdp_data.csv")
 log.info(f"Saving to {path}")
 df.to_csv(path)
 log.info(f"Script complete")


### PR DESCRIPTION
To quote the [Corona Data Scraper](https://coronadatascraper.com) web page,

> Corona Data Scraper pulls COVID-19 Coronavirus case data from verified sources, finds the corresponding GeoJSON features, and adds population data.

We transform this data for use in the Covasim parameter format. It is stored
in CSV-format. 

The following columns are present in the data:

- name: Apparently, a unique name for the data set
- level: level of the data (country, state, county, city)
- city: The city name
- county: The county or parish
- state: The state, province, or region
- country: [ ISO 3166-1 alpha-3 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)
- population: The estimated population of the location
- lat: latitude
- long: longitude
- url: Data source
- aggregate
- tz: Time zone
- recovered: Cumulative number recovered (as of date)
- active: Cumulative number active (as of date)
- growthFactor:
- date: Date in yyyy-MM-dd text format
- day: Number of days since first reporting
- positives: Cumulative number of positive cases (as of date)
- death: Cumulative number of deaths (as of date)
- tests: Cumulative number of tests (as of date)
- new_positives: New positives on this date
- new_active: New active cases on this date
- new_death: Number of deaths on this date
- new_tests: New tests on this date

As of April 4, 2020, There are apparently 3280 data sets.

Data is placed in the `data` directory.
Loader is in the `data_loader` directory.

Partial completion of https://github.com/InstituteforDiseaseModeling/covasim/issues/43