### PR TITLE
Use position: relative to fix height issue on scroll

### DIFF
--- a/covasim/webapp/cova_app.css
+++ b/covasim/webapp/cova_app.css
@@ -107,4 +107,5 @@ header.row, footer.row {
 .chart-frame {
     overflow: hidden auto;
     max-height: 75vh;
+    position: relative;
 }


### PR DESCRIPTION
There is an issue where the content of the graphs div overflows and extends the height of the page. This is caused by the fact that the overflow parent is not specified as "non-static" (I think). By explicitly stating "position: relative" we tell the browsers to render this properly.

Note, only some browsers were broken. chrome and safari were tested as broken, firefox did not break.

<img width="1466" alt="image" src="https://user-images.githubusercontent.com/3074765/78510644-d3ad3400-7764-11ea-9bb3-cb759bc38d81.png">


cc @cliffckerr 

Fixes https://github.com/InstituteforDiseaseModeling/covasim/issues/65