### PR TITLE
Update python scripts to have CLI entry points -- first example with run_sim.py

### DIFF
--- a/examples/run_sim.py
+++ b/examples/run_sim.py
@@ -5,15 +5,7 @@ Simple script for running the Covid-19 agent-based model
 print('Importing...')
 import sciris as sc
 import covasim as cv
-
-print('Configuring...')
-
-# Run options
-do_plot = 1
-do_save = 0
-do_show = 1
-verbose = 1
-interv  = 0
+import fire
 
 # Set filename if saving
 version  = 'v0'
@@ -30,16 +22,51 @@ pars = sc.objdict(
     rand_seed    = 1,     # Random seed
     )
 
-# Optionally add an intervention
-if interv:
-    pars.interventions = cv.change_beta(days=45, changes=0.5) # Optionally add an intervention
+def run(pars=pars, 
+        interv=False,
+        verbose=True,
+        do_plot=True, 
+        do_save=False, 
+        do_show=True,
+        fig_path=fig_path
+        ):
 
-print('Making sim...')
-sim = cv.Sim(pars=pars)
+    '''
+    Run simulation, optionally with an intervention.
 
-print('Running...')
-sim.run(verbose=verbose)
+    To run simulation with default parameters:
+    > python rum_sim.py
 
-if do_plot:
-    print('Plotting...')
-    fig = sim.plot(do_save=do_save, do_show=do_show, fig_path=fig_path)
+    To run simulation with an intervention:
+    > python run_sim.py --interv=True
+
+    To run simulation with an intervention and save plot to disk:
+    > python run_sim.py --interv=True --do_save=True
+
+    To run simulation with custom configuration
+    > python run_sim.py --pars "{pop_size:20000, pop_infected:1, n_days:360, rand_seed:1}"
+
+    Args:
+        pars: (dict): configuration for the sim.  See description for example.
+        interv: (bool): whether or not to add an intervention, specified by cv.change_beta(days=45, changes=0.5)
+        do_plot: (bool): whether or not to generate a plot.  Defaults to True.
+        do_save: (bool): If a plot is generated, whether or not to save it.  Defaults to False.
+        do_show: (bool): If a plot is generated, whether or not to show it.  Defaults to True.
+        fig_path: (str): Path to which save filename.  Defaults to results/covasim_run_{date}_{version}.png
+        verbose: (bool): whether or not turn verbose mode while running simulation
+    '''
+    if interv: 
+        pars.interventions = cv.change_beta(days=45, changes=0.5) # Optionally add an intervention
+    
+    print('Making sim...')
+    sim = cv.Sim(pars=pars)
+
+    print('Running...')
+    sim.run(verbose=verbose)
+
+    if do_plot:
+        print('Plotting...')
+        fig = sim.plot(do_save=do_save, do_show=do_show, fig_path=fig_path)
+
+if __name__ == '__main__':
+    fire.Fire(run)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sciris
 scirisweb
 gunicorn
 plotly_express
+fire==0.3.1


### PR DESCRIPTION
This is related to https://github.com/InstituteforDiseaseModeling/covasim/issues/8

I started this on one of the helper files for illustrative purposes but we can enable CLI entry points on all important scripts.  **Note** You can still run this file per normal 

`python examples/run_sim.py`

However, now there are **additional** CLI entry points.  

cc: @inc0 @cliffckerr 

If this type of interface is amenable to everyone, **I can expand this other entry points in this repo -- just let me know which ones to prioritize.** 


## Per the proposed docstrings this is the cli interface

To run simulation with default parameters:
`python rum_sim.py`

To run simulation with an intervention:
`python run_sim.py --interv=True`

To run simulation with an intervention and save plot to disk:
`python run_sim.py --interv=True --do_save=True`

To run simulation with custom configuration
`python run_sim.py --pars "{pop_size:20000, pop_infected:1, n_days:360, rand_seed:1}"`
