### PR TITLE
Build docker on push to master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: Covasim CI workflow
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build_and_push_docker:
+    runs-on: ubuntu-latest
+    name: Build and Publish Docker Image
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+      - name: Build Docker
+        run: docker build -f docker/Dockerfile -t docker.pkg.github.com/${{ github.repository }}/covasim:latest .
+      - name: Push the image to GPR
+        run: |
+          docker login docker.pkg.github.com -u publisher -p "${GITHUB_PACKAGE_REGISTRY_TOKEN}"
+          docker push docker.pkg.github.com/${{ github.repository }}/covasim:latest
+        env:
+          GITHUB_PACKAGE_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
What this does
---
- Adds a CI job that runs on master that publishes a package to the github package registry
- It can then be fetched using `docker.pkg.github.com/InstituteforDiseaseModeling/covasim/covasim:latest`
- Example on my fork is here: https://github.com/jules2689/covasim/packages/179707
- Here is how it looks in Actions running: https://github.com/jules2689/covasim/actions/runs/75647459