### PR TITLE
Automated Docs Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Build and Publish Docker Image
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set lowercase repo env variable
         shell: python

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,80 @@
+name: Covasim Docs workflow
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    if: github.repository == 'jules2689/covasim'
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        python-version: ['3.7']
+    name: Install and Generate Docs
+    steps:
+      - name: Set repo owner env variable
+        shell: python
+        run: print("::set-env name=GITHUB_OWNER::{}".format('${{github.repository}}'.split('/')[0]))
+      - name: Set repo owner env variable
+        shell: python
+        run: print("::set-env name=GITHUB_OWNER::{}".format('${{github.repository}}'.split('/')[0]))
+      - name: Set PYTHONPATH
+        run: |
+          mkdir -p $HOME/.cache/site-packages
+          echo "::set-env name=PYTHONPATH::$HOME/.cache/site-packages"
+      - name: Checkout Docs Repo
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.GITHUB_OWNER }}/covasim-docs
+          path: covasim-docs
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          path: covasim
+      - uses: actions/setup-python@master
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Cache Packages
+        id: cache-packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/ # This path is specific to Ubuntu
+          key: packages-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }} # Look to see if there is a cache hit for the corresponding requirements file
+          restore-keys: |
+            packages-${{ runner.os }}-${{ matrix.python-version }}- # Pip install first will make setup.py much faster and the cache will make pip install fast
+      - name: Install Covasim
+        run: |
+          pushd covasim
+          python setup.py develop --install-dir ~/.cache/site-packages
+          pip3 install -r docs/requirements.txt
+          popd
+      - name: Build Docs
+        run: |
+          pushd covasim/docs
+          make html
+          popd
+
+          rm -rf covasim-docs/*
+          rsync -r covasim/docs/_build/html/ covasim-docs/
+      - name: Commit Docs
+        run: |
+          pushd covasim-docs
+          if [ ! -z "$(git status --porcelain)" ]; then
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add --all .
+            git commit -m "Update Docs"
+            
+            # Setup deploy key
+            eval "$(ssh-agent -s)"
+            ssh-add - <<< "${{ secrets.DOCS_DEPLOY_KEY }}"
+
+            # Deploy
+            remote_repo="git@github.com:${{ env.GITHUB_OWNER }}/covasim-docs.git"
+            git push "${remote_repo}" HEAD:${{ github.ref }} --follow-tags
+          fi
+          popd

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: github.repository == 'jules2689/covasim'
+    if: github.repository == 'InstituteforDiseaseModeling/covasim'
     strategy:
       fail-fast: false
       max-parallel: 8
@@ -43,9 +43,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cache/ # This path is specific to Ubuntu
-          key: packages-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }} # Look to see if there is a cache hit for the corresponding requirements file
+          key: docs-packages-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}--${{ hashFiles('docs/requirements.txt') }} # Look to see if there is a cache hit for the corresponding requirements file
           restore-keys: |
-            packages-${{ runner.os }}-${{ matrix.python-version }}- # Pip install first will make setup.py much faster and the cache will make pip install fast
+            docs-packages-${{ runner.os }}-${{ matrix.python-version }}- # Pip install first will make setup.py much faster and the cache will make pip install fast
       - name: Install Covasim
         run: |
           pushd covasim

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -19,7 +19,7 @@ jobs:
           mkdir -p $HOME/.cache/site-packages
           echo "::set-env name=PYTHONPATH::$HOME/.cache/site-packages"
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - uses: actions/setup-python@master
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
What this does
---
- Introduces a docs worflow that can be seen working here: https://github.com/jules2689/covasim/actions/runs/80875622
- It is now restricted to run on InstituteforDiseaseModeling/covasim only
- Requires a Deploy Key to push as a personal access token cannot push. Here's how to set that up:
  1. Run `ssh-keygen `(no passphrase)
  2. On https://github.com/InstituteforDiseaseModeling/covasim-docs/settings/keys/new, add the public key here. Make sure to check "write access"
  3. On https://github.com/InstituteforDiseaseModeling/covasim/settings/secrets, add a new secret called `DOCS_DEPLOY_KEY` with the private ssh key