### PR TITLE
Docs redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+        <meta http-equiv="refresh" content="1;url=http://institutefordiseasemodeling.github.io/covasim-docs">
+        <script type="text/javascript">
+            window.location.href = "http://institutefordiseasemodeling.github.io/covasim-docs"
+        </script>
+        <title>Covasim Documentation | Redirect</title>
+    </head>
+    <body>
+        If you are not redirected automatically, please click<a href='http://institutefordiseasemodeling.github.io/covasim-docs'>here</a>.
+    </body>
+</html>

--- a/docs/variables.txt
+++ b/docs/variables.txt
@@ -16,7 +16,7 @@
 
 .. |IDM_l| replace:: Institute for Disease Modeling (IDM)
 .. |IDM_s| replace:: IDM
-.. |Cov_l| replace:: COVID-10 Agent-based Simulator (Covasim)
+.. |Cov_l| replace:: COVID-19 Agent-based Simulator (Covasim)
 .. |Cov_s| replace:: Covasim
 .. |Python_supp| replace:: Python >= 3.6 (64-bit)
 


### PR DESCRIPTION
Adds an HTML redirect so 

http://institutefordiseasemodeling.github.io/covasim

will redirect to

http://institutefordiseasemodeling.github.io/covasim-docs

After this is merged, GitHub pages settings will need to be updated to serve from master/docs, and the gh-pages branch can be deleted.

Closes https://github.com/InstituteforDiseaseModeling/covasim/issues/151