### PR TITLE
Added link to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,10 @@ also be used to explore the potential impact of different interventions, includi
 social distancing, school closures, testing, contact tracing, and quarantine.
 
 Questions or comments can be directed to covasim@idmod.org, or on this project's
-GitHub_ page.
+GitHub_ page. Full information about Covasim is provided in the documentation_.
 
 .. _GitHub: https://github.com/institutefordiseasemodeling/covasim
+.. _documentation: https://institutefordiseasemodeling.github.io/covasim-docs
 
 .. contents:: Contents
    :local:


### PR DESCRIPTION
Adds a link to the docs from the readme. Closes #186. Not ideal that the documentation includes a link to itself now, but probably not worth worrying about for now.