### PR TITLE
#202: Increase comprehension via tooltips and input transparency

### DIFF
--- a/covasim/webapp/cova_app.js
+++ b/covasim/webapp/cova_app.js
@@ -34,9 +34,11 @@ const PlotlyChart = {
 const interventionTableConfig = {
     social_distance: {
         formTitle: "Physical distancing",
-        fields: [{key: 'start', type: 'number', label: 'Start day'},
-            {key: 'end', type: 'number', label: 'End day'},
-            {label: 'Effectiveness', key: 'level', type: 'select', options: [{label: 'Aggressive (80%)', value: 'aggressive'}, {label: 'Moderate (50%)', value: 'moderate'}, {label: 'Mild (20%)', value: 'mild'}]}],
+        fields: [
+            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day'},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'},
+            {key: 'level', type: 'number', label: 'Effectiveness', tooltip: 'Effectiveness', min: 0, max: 100}
+        ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);
             const end = parseInt(event.target.elements.end.value);
@@ -46,7 +48,10 @@ const interventionTableConfig = {
     },
     school_closures: {
         formTitle: "School closures",
-        fields: [{key: 'start', type: 'number', label: 'Start day'}, {key: 'end', type: 'number', label: 'End day'}],
+        fields: [
+            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day'},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'}
+        ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);
             const end = parseInt(event.target.elements.end.value);
@@ -55,7 +60,11 @@ const interventionTableConfig = {
     },
     symptomatic_testing: {
         formTitle: "Symptomatic testing",
-        fields: [{key: 'start', type: 'number', label: 'Start day'}, {key: 'end', type: 'number', label: 'End day'}, {label: 'Coverage', key: 'level', type: 'select', options: [{label: '10% per day', value: '10'}, {label: '30% per day', value: '30'},]}],
+        fields: [
+            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day'},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'},
+            {key: 'level', type: 'number', label: 'Coverage', tooltip: 'Test coverage', min: 0, max: 100}
+        ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);
             const end = parseInt(event.target.elements.end.value);
@@ -65,7 +74,10 @@ const interventionTableConfig = {
     },
     contact_tracing: {
         formTitle: "Contact tracing",
-        fields: [{key: 'start', type: 'number', label: 'Start Day'}, {key: 'end', type: 'number', label: 'End day'}],
+        fields: [
+            {key: 'start', type: 'number', label: 'Start Day', tooltip: 'Start day'},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'}
+        ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);
             const end = parseInt(event.target.elements.end.value);

--- a/covasim/webapp/cova_app.js
+++ b/covasim/webapp/cova_app.js
@@ -35,9 +35,9 @@ const interventionTableConfig = {
     social_distance: {
         formTitle: "Physical distancing",
         fields: [
-            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day'},
-            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'},
-            {key: 'level', type: 'number', label: 'Effectiveness', tooltip: 'Effectiveness', min: 0, max: 100}
+            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day', defaultValue: () => 0},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day',  defaultValue: () => vm.sim_length.best},
+            {key: 'level', type: 'number', label: 'Effectiveness', tooltip: 'Effectiveness', min: 0, max: 100, defaultValue: () => 100}
         ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);
@@ -49,8 +49,8 @@ const interventionTableConfig = {
     school_closures: {
         formTitle: "School closures",
         fields: [
-            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day'},
-            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'}
+            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day', defaultValue: () => vm.sim_length.min},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day', defaultValue: () => vm.sim_length.best}
         ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);
@@ -61,9 +61,9 @@ const interventionTableConfig = {
     symptomatic_testing: {
         formTitle: "Symptomatic testing",
         fields: [
-            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day'},
-            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'},
-            {key: 'level', type: 'number', label: 'Coverage', tooltip: 'Test coverage', min: 0, max: 100}
+            {key: 'start', type: 'number', label: 'Start day', tooltip: 'Start day', defaultValue: () => vm.sim_length.min},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day',  defaultValue: () => vm.sim_length.best},
+            {key: 'level', type: 'number', label: 'Coverage', tooltip: 'Test coverage', min: 0, max: 100, defaultValue: () => 100}
         ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);
@@ -75,8 +75,8 @@ const interventionTableConfig = {
     contact_tracing: {
         formTitle: "Contact tracing",
         fields: [
-            {key: 'start', type: 'number', label: 'Start Day', tooltip: 'Start day'},
-            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day'}
+            {key: 'start', type: 'number', label: 'Start Day', tooltip: 'Start day', defaultValue: () => vm.sim_length.min},
+            {key: 'end', type: 'number', label: 'End day', tooltip: 'End day', defaultValue: () => vm.sim_length.best}
         ],
         handleSubmit: function(event) {
             const start = parseInt(event.target.elements.start.value);

--- a/covasim/webapp/cova_app.py
+++ b/covasim/webapp/cova_app.py
@@ -110,7 +110,7 @@ def get_defaults(region=None, merge=False, die=die):
         pop_infected = dict(best=10,    min=1, max=max_pop,  name='Initial infections',         tip='Number of initial seed infections in the model'),
         # n_imports    = dict(best=0,     min=0, max=100,      name='Daily imported infections',  tip='Number of infections that are imported each day'),
         rand_seed    = dict(best=0,     min=0, max=100,      name='Random seed',                tip='Random number seed (set to 0 for different results each time)'),
-        n_days       = dict(best=90,    min=1, max=max_days, name="Simulation duration",        tip='Total duration (in days) of the simulation'),
+        n_days       = dict(best=90,    min=0, max=max_days, name="Simulation duration",        tip='Total duration (in days) of the simulation'),
     )
 
     epi_pars = dict(

--- a/covasim/webapp/cova_app.py
+++ b/covasim/webapp/cova_app.py
@@ -196,7 +196,7 @@ def get_gantt(int_pars=None, intervention_config=None):
     for key,scenario in int_pars.items():
         for timeline in scenario:
             task = intervention_config[key]['formTitle']
-            level = task + ' ' + str(timeline.get('level', ''))
+            level = task + ' ' + str(timeline.get('level', '')) + '%'
             df.append(dict(Task=task, Start=timeline['start'], Finish=timeline['end'], Level= level))
     if len(df) > 0:
         fig = ff.create_gantt(df, height=400, index_col='Level', title='Intervention timeline',
@@ -242,12 +242,7 @@ def parse_interventions(int_pars):
             end   = iconfig['end']
             if ikey == 'social_distance':
                 level = iconfig['level']
-                mapping = {
-                    'mild': 0.8,
-                    'moderate': 0.5,
-                    'aggressive': 0.2,
-                    }
-                change = mapping[level]
+                change = float(level)/100
                 interv = cv.change_beta(days=[start, end], changes=[change, 1.0])
             elif ikey == 'school_closures':
                 change = 0.0

--- a/covasim/webapp/index.html
+++ b/covasim/webapp/index.html
@@ -195,7 +195,7 @@
                               {{par[field.key]}}<span v-if="field.key=== 'level'">%</span>
                             </td>
                             <td>
-                              <button @click="deleteIntervention(name, index)" class="btn btn-outline-secondary" type="button">Delete</button>
+                              <button @click="deleteIntervention(name, index)" class="btn btn-outline-danger" type="button">Delete</button>
                             </td>
                           </tr>
                           </tbody>

--- a/covasim/webapp/index.html
+++ b/covasim/webapp/index.html
@@ -164,11 +164,22 @@
                         <div class="form-group">
                           <div class="input-group mb-3">
                             <template v-for="field in intervention.fields">
-                              <input :max="field.max || sim_length.max" :min="field.min || 0" :placeholder="field.label" :name="field.key"
-                                     :aria-label="field.label" class="form-control" v-if="field.type !== 'select'"
-                                     :type="field.type" v-b-tooltip.hover :title="field.tooltip">
-                              <select class="form-control" :name="field.key" v-else>
-                                <option v-for="option in field.options" :value="option.value">{{option.label}}</option>
+                              <input v-if="field.type !== 'select'"
+                                     :name="field.key"
+                                     :max="field.max || sim_length.max"
+                                     :min="field.min || 0"
+                                     :placeholder="field.label"
+                                     :aria-label="field.label"
+                                     :type="field.type"
+                                     :value="field.defaultValue? field.defaultValue() : undefined"
+                                     v-b-tooltip.hover :title="field.tooltip"
+                                     class="form-control">
+                              <select v-else
+                                      :name="field.key"
+                                      class="form-control">
+                                <option v-for="option in field.options" :value="option.value" :selected="option.selected">
+                                  {{option.label}}
+                                </option>
                               </select>
                               <div class="input-group-append" v-if="field.key === 'level'">
                                 <span class="input-group-text">%</span>
@@ -192,7 +203,7 @@
                           <tbody>
                           <tr v-for="(par, index) in int_pars[name]">
                             <td v-for="field in intervention.fields" scope="row">
-                              {{par[field.key]}}<span v-if="field.key=== 'level'">%</span>
+                              {{par[field.key]}}<span v-if="field.key === 'level'">%</span>
                             </td>
                             <td>
                               <button @click="deleteIntervention(name, index)" class="btn btn-outline-danger" type="button">Delete</button>

--- a/covasim/webapp/index.html
+++ b/covasim/webapp/index.html
@@ -164,10 +164,15 @@
                         <div class="form-group">
                           <div class="input-group mb-3">
                             <template v-for="field in intervention.fields">
-                              <input :max="sim_length.max" :min="0" :placeholder="field.label" :name="field.key" :aria-label="field.label" class="form-control" v-if="field.type !== 'select'" :type="field.type">
+                              <input :max="field.max || sim_length.max" :min="field.min || 0" :placeholder="field.label" :name="field.key"
+                                     :aria-label="field.label" class="form-control" v-if="field.type !== 'select'"
+                                     :type="field.type" v-b-tooltip.hover :title="field.tooltip">
                               <select class="form-control" :name="field.key" v-else>
                                 <option v-for="option in field.options" :value="option.value">{{option.label}}</option>
                               </select>
+                              <div class="input-group-append" v-if="field.key === 'level'">
+                                <span class="input-group-text">%</span>
+                              </div>
                             </template>
                             <div class="input-group-append">
                               <button class="btn btn-outline-secondary" type="submit">Add intervention</button>
@@ -186,7 +191,9 @@
                           </thead>
                           <tbody>
                           <tr v-for="(par, index) in int_pars[name]">
-                            <th v-for="field in intervention.fields" scope="row">{{par[field.key]}}</th>
+                            <td v-for="field in intervention.fields" scope="row">
+                              {{par[field.key]}}<span v-if="field.key=== 'level'">%</span>
+                            </td>
                             <td>
                               <button @click="deleteIntervention(name, index)" class="btn btn-outline-secondary" type="button">Delete</button>
                             </td>


### PR DESCRIPTION
- Added tooltips for intervention form fields
- Changed intervention level to use number input that gets translated to a float between 0 and 1.
- Tooltips currently just use field label. 
- Closes #202 
![image](https://user-images.githubusercontent.com/43424134/80522199-094ad480-8941-11ea-8dc7-ca74ad49e38c.png)
