### PR TITLE
Scatter animation

### DIFF
--- a/tests/devtests/plotly_tests.py
+++ b/tests/devtests/plotly_tests.py
@@ -7,4 +7,4 @@ pio.renderers.default = "browser"
 sim = cv.Sim(pop_size=10e3)
 
 sim.run()
-fig = cv.animate_people(sim, do_show=True)
+fig = cv.plotly_animate(sim, do_show=True)


### PR DESCRIPTION
Scatter plot instead of heatmap for animation. Addresses https://github.com/InstituteforDiseaseModeling/covasim/issues/220, and I think it looks much better, but is too slow to be practical (1000 people takes 10-15 s, 10k people crashes). @RomeshA @lgeorge-idm if one of you can find a way to make it faster (@RomeshA I know you already tried), maybe we can use this, otherwise we can close the ticket and keep the heatmap.
![image](https://user-images.githubusercontent.com/3239256/80932906-592cff80-8d76-11ea-9318-6c39b7ea3935.png)
