### PR TITLE
docs: add redirect rules and indexing rules

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -2,6 +2,12 @@
 
 {% set css_files = css_files + ["_static/theme_overrides.css"] %}
 
+{% block htmltitle %}
+{{ super() }}
+<meta name="robots" content="none">
+<meta http-equiv="refresh" content="0; URL={{ rtd_url }}/{{ pagename }}{{ file_suffix }}">
+{% endblock %}
+
 {% block extrahead %}
 
 <link href="https://fonts.googleapis.com/css?family=Lato|Montserrat|Open+Sans" rel="stylesheet">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,6 +200,7 @@ html_favicon = "images/favicon.ico"
 html_static_path = ['_static']
 
 html_context = {
+    'rtd_url': 'https://docs.idmod.org/projects/covasim/en/latest',
     'css_files': [
         '_static/theme_overrides.css'
     ]
@@ -208,7 +209,7 @@ html_context = {
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
 #
-# html_extra_path = []
+html_extra_path = ['robots.txt']
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.
@@ -258,7 +259,7 @@ html_show_sphinx = False
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
 #
-html_use_opensearch = 'www.idmod.org/docs/'
+html_use_opensearch = 'docs.idmod.org/projects/covasim/en/latest'
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 # html_file_suffix = None

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,2 @@
+user-agent: *
+disallow: /


### PR DESCRIPTION
Updated docs to redirect to docs.idmod.org. Not to be merged until the documentation on RTD is public.