### PR TITLE
Pinned numba to 0.48.0 to fix Read the Docs build error

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,12 +21,12 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
-   install:
-      - requirements: docs/requirements.txt
-      - method: setuptools
-        path: .
-    system_packages: true
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .
+  system_packages: true
     
 # Optionally rank topics in search results, between -10 (lower) and 10 (higher).
 # 0 is normal rank, not no rank

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,7 @@ autodoc_default_options = {
     'members': None
 }
 
-autodoc_mock_imports = ['llvmlite',
-                        'numba']
+autodoc_mock_imports = []
 
 
 napoleon_google_docstring = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ autodoc_default_options = {
     'members': None
 }
 
-autodoc_mock_imports = []
+autodoc_mock_imports = ['llvmlite']
 
 
 napoleon_google_docstring = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,8 @@ autodoc_default_options = {
     'members': None
 }
 
-autodoc_mock_imports = ['llvmlite']
+autodoc_mock_imports = ['llvmlite',
+                        'numba']
 
 
 napoleon_google_docstring = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinxcontrib-napoleon~=0.7
 sphinx~=3.2.0
 plantweb~=1.2.1
 pytest
+numba==0.48.0


### PR DESCRIPTION
I'm not entirely sure why this works, but it does. Also cleaned up indentation in the YAML file so I don't keep accidentally misaligning variables. 