### PR TITLE
Fix compute_r_eff() error message

### DIFF
--- a/covasim/sim.py
+++ b/covasim/sim.py
@@ -811,7 +811,7 @@ class Sim(cvb.BaseSim):
 
         # Method not recognized
         else:
-            errormsg = f'Method must be "daily", "infected", or "outcome", not "{method}"'
+            errormsg = f'Method must be "daily", "infectious", or "outcome", not "{method}"'
             raise ValueError(errormsg)
 
         # Set the values and return


### PR DESCRIPTION
If you pass an unrecognized method name to _.compute_r_eff()_ it raises an exception having the following error message: 'Method must be "daily", "**infected**", or "outcome", not "{method}"', but the accepted method names are "daily", "**infectious**" and "outcome".

This pull request fixes the error message.