### PR TITLE
Minor comment improvements (misspeling inf2sym and infect)

### DIFF
--- a/covasim/README.rst
+++ b/covasim/README.rst
@@ -45,7 +45,7 @@ Efficacy of protection measures
 
 Time for disease progression
 ----------------------------
-* ``exp2inf``  = Duration from exposed to infectious; see Lauer et al., https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7081172/, subtracting inf2sim duration
+* ``exp2inf``  = Duration from exposed to infectious; see Lauer et al., https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7081172/, subtracting inf2sym duration
 * ``inf2sym``  = Duration from infectious to symptomatic; see Linton et al., https://doi.org/10.3390/jcm9020538
 * ``sym2sev``  = Duration from symptomatic to severe symptoms; see Linton et al., https://doi.org/10.3390/jcm9020538Duration from severe symptoms to requiring ICU; see Wang et al., https://jamanetwork.com/journals/jama/fullarticle/2761044Duration from severe symptoms to requiring ICU
 

--- a/covasim/parameters.py
+++ b/covasim/parameters.py
@@ -64,7 +64,7 @@ def make_pars(set_prognoses=False, prog_by_age=True, version=None, **kwargs):
 
     # Duration parameters: time for disease progression
     pars['dur'] = {}
-    pars['dur']['exp2inf']  = dict(dist='lognormal_int', par1=4.6, par2=4.8) # Duration from exposed to infectious; see Lauer et al., https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7081172/, subtracting inf2sim duration
+    pars['dur']['exp2inf']  = dict(dist='lognormal_int', par1=4.6, par2=4.8) # Duration from exposed to infectious; see Lauer et al., https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7081172/, subtracting inf2sym duration
     pars['dur']['inf2sym']  = dict(dist='lognormal_int', par1=1.0, par2=0.9) # Duration from infectious to symptomatic; see Linton et al., https://doi.org/10.3390/jcm9020538
     pars['dur']['sym2sev']  = dict(dist='lognormal_int', par1=6.6, par2=4.9) # Duration from symptomatic to severe symptoms; see Linton et al., https://doi.org/10.3390/jcm9020538
     pars['dur']['sev2crit'] = dict(dist='lognormal_int', par1=3.0, par2=7.4) # Duration from severe symptoms to requiring ICU; see Wang et al., https://jamanetwork.com/journals/jama/fullarticle/2761044

--- a/covasim/people.py
+++ b/covasim/people.py
@@ -329,6 +329,8 @@ class People(cvb.BasePeople):
             * Infected people that develop symptoms are disaggregated into mild vs. severe (=requires hospitalization) vs. critical (=requires ICU)
             * Every asymptomatic, mildly symptomatic, and severely symptomatic person recovers
             * Critical cases either recover or die
+        Method also deduplicates input arrays in case one agent is infected many times 
+        and stores who infected whom in infection_log list.
 
         Args:
             inds     (array): array of people to infect


### PR DESCRIPTION
Just minor improvements in misspelling inf2sim -> inf2sym. 
and improved description of of def infect to let know that we infection_log is automatically populated there (to give e.g. possibility of super-spreader tracking in post-processing).