### PR TITLE
Aggregate attempt of migrate

### DIFF
--- a/covasim/misc.py
+++ b/covasim/misc.py
@@ -127,7 +127,7 @@ def load(*args, do_migrate=True, update=True, verbose=True, **kwargs):
         if cmp != 0:
             print(f'Note: you have Covasim v{v_curr}, but are loading an object from v{v_obj}')
             if do_migrate:
-                obj = migrate(obj, update=update, verbose=verbose)
+                obj = migrateVarious.migrate(obj, update=update, verbose=verbose)
     return obj
 
 
@@ -208,7 +208,7 @@ def savefig(filename=None, comments=None, **kwargs):
 __all__ += ['migrate']
 
 
-class migrate:
+class migrateVarious:
     def __init__(self,pars,obj):
         self.pars = pars
         self.obj = obj
@@ -317,14 +317,14 @@ class migrate:
                 if verbose:
                     print(f'Migrating sim from version {sim.version} to version {cvv.__version__}')
                     print('Note: updating lognormal stds to restore previous behavior; see v2.1.0 changelog for details')
-                migrate_lognormal(sim.pars, verbose=verbose)
+                self.migrate_lognormal(sim.pars, verbose=verbose)
 
             # Migration from <3.0.0 to 3.0.0
             if sc.compareversions(sim.version, '3.0.0') == -1:
                 if verbose:
                     print(f'Migrating sim from version {sim.version} to version {cvv.__version__}')
                     print('Adding variant parameters')
-                migrate_variants(sim.pars, verbose=verbose)
+                self.migrate_variants(sim.pars, verbose=verbose)
 
         # Migrations for People
         elif isinstance(obj, cvb.BasePeople): # pragma: no cover

--- a/covasim/parameters.py
+++ b/covasim/parameters.py
@@ -143,7 +143,7 @@ def make_pars(set_prognoses=False, prog_by_age=True, version=None, **kwargs):
 
         # Handle code change migration
         if sc.compareversions(version, '2.1.0') == -1 and 'migrate_lognormal' not in pars:
-            cvm.migrate.migrate_lognormal(pars, verbose=pars['verbose'])
+            cvm.migrateVarious.migrate_lognormal(pars, verbose=pars['verbose'])
 
     return pars
 

--- a/covasim/parameters.py
+++ b/covasim/parameters.py
@@ -143,7 +143,7 @@ def make_pars(set_prognoses=False, prog_by_age=True, version=None, **kwargs):
 
         # Handle code change migration
         if sc.compareversions(version, '2.1.0') == -1 and 'migrate_lognormal' not in pars:
-            cvm.migrate_lognormal(pars, verbose=pars['verbose'])
+            cvm.migrate.migrate_lognormal(pars, verbose=pars['verbose'])
 
     return pars
 


### PR DESCRIPTION
####Reference PR: 
Several functions in the misc.py are aggregated together

####Explaination of slight modification: 
The main change is to make those migrate into the root migrateVarious. Because in a model with complex relationships, it is difficult to guarantee consistency of object changes. By using this change, when it comes to things like invariants, we can think of the methods as a single unit.  

####These changes are part of the lab of our course project.