### PR TITLE
Add Aggregate Population to population.py

### DIFF
--- a/covasim/population.py
+++ b/covasim/population.py
@@ -15,392 +15,396 @@ from . import parameters as cvpar
 from . import people as cvppl
 
 
-# Specify all externally visible functions this file defines
-__all__ = ['make_people', 'make_randpop', 'make_random_contacts',
-           'make_microstructured_contacts', 'make_hybrid_contacts',
-           'make_synthpop']
+# # Specify all externally visible functions this file defines
+# __all__ = ['make_people', 'make_randpop', 'make_random_contacts',
+#            'make_microstructured_contacts', 'make_hybrid_contacts',
+#            'make_synthpop']
 
+class Population:
+    def __init__(self, sim, **kwargs):
+        self.people = self.make_people(sim, **kwargs)
+        return
+        
+    def make_people(self, sim, popdict=None, save_pop=False, popfile=None, die=True, reset=False, verbose=None, **kwargs):
+        '''
+        Make the actual people for the simulation. Usually called via sim.initialize(),
+        but can be called directly by the user.
 
-def make_people(sim, popdict=None, save_pop=False, popfile=None, die=True, reset=False, verbose=None, **kwargs):
-    '''
-    Make the actual people for the simulation. Usually called via sim.initialize(),
-    but can be called directly by the user.
+        Args:
+            sim      (Sim)  : the simulation object; population parameters are taken from the sim object
+            popdict  (dict) : if supplied, use this population dictionary instead of generating a new one
+            save_pop (bool) : whether to save the population to disk
+            popfile  (bool) : if so, the filename to save to
+            die      (bool) : whether or not to fail if synthetic populations are requested but not available
+            reset    (bool) : whether to force population creation even if self.popdict/self.people exists
+            verbose  (bool) : level of detail to print
+            kwargs   (dict) : passed to make_randpop() or make_synthpop()
 
-    Args:
-        sim      (Sim)  : the simulation object; population parameters are taken from the sim object
-        popdict  (dict) : if supplied, use this population dictionary instead of generating a new one
-        save_pop (bool) : whether to save the population to disk
-        popfile  (bool) : if so, the filename to save to
-        die      (bool) : whether or not to fail if synthetic populations are requested but not available
-        reset    (bool) : whether to force population creation even if self.popdict/self.people exists
-        verbose  (bool) : level of detail to print
-        kwargs   (dict) : passed to make_randpop() or make_synthpop()
+        Returns:
+            people (People): people
+        '''
 
-    Returns:
-        people (People): people
-    '''
+        # Set inputs and defaults
+        pop_size = int(sim['pop_size']) # Shorten
+        pop_type = sim['pop_type'] # Shorten
+        if verbose is None:
+            verbose = sim['verbose']
+        if popfile is None:
+            popfile = sim.popfile
 
-    # Set inputs and defaults
-    pop_size = int(sim['pop_size']) # Shorten
-    pop_type = sim['pop_type'] # Shorten
-    if verbose is None:
-        verbose = sim['verbose']
-    if popfile is None:
-        popfile = sim.popfile
-
-    # Check which type of population to produce
-    if pop_type == 'synthpops':
-        if not cvreq.check_synthpops(): # pragma: no cover
-            errormsg = f'You have requested "{pop_type}" population, but synthpops is not available; please use random, clustered, or hybrid'
-            if die:
-                raise ValueError(errormsg)
-            else:
-                print(errormsg)
-                pop_type = 'random'
-
-        location = sim['location']
-        if location: # pragma: no cover
-            print(f'Warning: not setting ages or contacts for "{location}" since synthpops contacts are pre-generated')
-
-    # Actually create the population
-    if sim.people and not reset:
-        return sim.people # If it's already there, just return
-    elif sim.popdict and not reset:
-        popdict = sim.popdict # Use stored one
-        sim.popdict = None # Once loaded, remove
-    elif popdict is None: # Main use case: no popdict is supplied
-        # Create the population
-        if pop_type in ['random', 'clustered', 'hybrid']:
-            popdict = make_randpop(sim, microstructure=pop_type, **kwargs)
-        elif pop_type == 'synthpops':
-            popdict = make_synthpop(sim, **kwargs)
-        elif pop_type is None: # pragma: no cover
-            errormsg = 'You have set pop_type=None. This is fine, but you must ensure sim.popdict exists before calling make_people().'
-            raise ValueError(errormsg)
-        else: # pragma: no cover
-            errormsg = f'Population type "{pop_type}" not found; choices are random, clustered, hybrid, or synthpops'
-            raise ValueError(errormsg)
-
-    # Ensure prognoses are set
-    if sim['prognoses'] is None:
-        sim['prognoses'] = cvpar.get_prognoses(sim['prog_by_age'], version=sim._default_ver)
-
-    # Actually create the people
-    people = cvppl.People(sim.pars, uid=popdict['uid'], age=popdict['age'], sex=popdict['sex'], contacts=popdict['contacts']) # List for storing the people
-
-    average_age = sum(popdict['age']/pop_size)
-    sc.printv(f'Created {pop_size} people, average age {average_age:0.2f} years', 2, verbose)
-
-    if save_pop:
-        if popfile is None: # pragma: no cover
-            errormsg = 'Please specify a file to save to using the popfile kwarg'
-            raise FileNotFoundError(errormsg)
-        else:
-            filepath = sc.makefilepath(filename=popfile)
-            cvm.save(filepath, people)
-            if verbose:
-                print(f'Saved population of type "{pop_type}" with {pop_size:n} people to {filepath}')
-
-    return people
-
-
-def make_randpop(sim, use_age_data=True, use_household_data=True, sex_ratio=0.5, microstructure=False):
-    '''
-    Make a random population, with contacts.
-
-    This function returns a "popdict" dictionary, which has the following (required) keys:
-
-        - uid: an array of (usually consecutive) integers of length N, uniquely identifying each agent
-        - age: an array of floats of length N, the age in years of each agent
-        - sex: an array of integers of length N (not currently used, so does not have to be binary)
-        - contacts: list of length N listing the contacts; see make_random_contacts() for details
-        - layer_keys: a list of strings representing the different contact layers in the population; see make_random_contacts() for details
-
-    Args:
-        sim (Sim): the simulation object
-        use_age_data (bool): whether to use location-specific age data
-        use_household_data (bool): whether to use location-specific household size data
-        sex_ratio (float): proportion of the population that is male (not currently used)
-        microstructure (bool): whether or not to use the microstructuring algorithm to group contacts
-
-    Returns:
-        popdict (dict): a dictionary representing the population, with the following keys for a population of N agents with M contacts between them:
-    '''
-
-    pop_size = int(sim['pop_size']) # Number of people
-
-    # Load age data and household demographics based on 2018 Seattle demographics by default, or country if available
-    age_data = cvd.default_age_data
-    location = sim['location']
-    if location is not None:
-        if sim['verbose']:
-            print(f'Loading location-specific data for "{location}"')
-        if use_age_data:
-            try:
-                age_data = cvdata.get_age_distribution(location)
-            except ValueError as E:
-                print(f'Could not load age data for requested location "{location}" ({str(E)}), using default')
-        if use_household_data:
-            try:
-                household_size = cvdata.get_household_size(location)
-                if 'h' in sim['contacts']:
-                    sim['contacts']['h'] = household_size - 1 # Subtract 1 because e.g. each person in a 3-person household has 2 contacts
+        # Check which type of population to produce
+        if pop_type == 'synthpops':
+            if not cvreq.check_synthpops(): # pragma: no cover
+                errormsg = f'You have requested "{pop_type}" population, but synthpops is not available; please use random, clustered, or hybrid'
+                if die:
+                    raise ValueError(errormsg)
                 else:
-                    keystr = ', '.join(list(sim['contacts'].keys()))
-                    print(f'Warning; not loading household size for "{location}" since no "h" key; keys are "{keystr}". Try "hybrid" population type?')
-            except ValueError as E:
-                if sim['verbose']>=2: # These don't exist for many locations, so skip the warning by default
-                    print(f'Could not load household size data for requested location "{location}" ({str(E)}), using default')
+                    print(errormsg)
+                    pop_type = 'random'
 
-    # Handle sexes and ages
-    uids           = np.arange(pop_size, dtype=cvd.default_int)
-    sexes          = np.random.binomial(1, sex_ratio, pop_size)
-    age_data_min   = age_data[:,0]
-    age_data_max   = age_data[:,1] + 1 # Since actually e.g. 69.999
-    age_data_range = age_data_max - age_data_min
-    age_data_prob  = age_data[:,2]
-    age_data_prob /= age_data_prob.sum() # Ensure it sums to 1
-    age_bins       = cvu.n_multinomial(age_data_prob, pop_size) # Choose age bins
-    ages           = age_data_min[age_bins] + age_data_range[age_bins]*np.random.random(pop_size) # Uniformly distribute within this age bin
+            location = sim['location']
+            if location: # pragma: no cover
+                print(f'Warning: not setting ages or contacts for "{location}" since synthpops contacts are pre-generated')
 
-    # Store output
-    popdict = {}
-    popdict['uid'] = uids
-    popdict['age'] = ages
-    popdict['sex'] = sexes
+        # Actually create the population
+        if sim.people and not reset:
+            return sim.people # If it's already there, just return
+        elif sim.popdict and not reset:
+            popdict = sim.popdict # Use stored one
+            sim.popdict = None # Once loaded, remove
+        elif popdict is None: # Main use case: no popdict is supplied
+            # Create the population
+            if pop_type in ['random', 'clustered', 'hybrid']:
+                popdict = self.make_randpop(sim, microstructure=pop_type, **kwargs)
+            elif pop_type == 'synthpops':
+                popdict = self.make_synthpop(sim, **kwargs)
+            elif pop_type is None: # pragma: no cover
+                errormsg = 'You have set pop_type=None. This is fine, but you must ensure sim.popdict exists before calling make_people().'
+                raise ValueError(errormsg)
+            else: # pragma: no cover
+                errormsg = f'Population type "{pop_type}" not found; choices are random, clustered, hybrid, or synthpops'
+                raise ValueError(errormsg)
 
-    # Actually create the contacts
-    if   microstructure == 'random':    contacts, layer_keys    = make_random_contacts(pop_size, sim['contacts'])
-    elif microstructure == 'clustered': contacts, layer_keys, _ = make_microstructured_contacts(pop_size, sim['contacts'])
-    elif microstructure == 'hybrid':    contacts, layer_keys, _ = make_hybrid_contacts(pop_size, ages, sim['contacts'])
-    else: # pragma: no cover
-        errormsg = f'Microstructure type "{microstructure}" not found; choices are random, clustered, or hybrid'
-        raise NotImplementedError(errormsg)
+        # Ensure prognoses are set
+        if sim['prognoses'] is None:
+            sim['prognoses'] = cvpar.get_prognoses(sim['prog_by_age'], version=sim._default_ver)
 
-    popdict['contacts']   = contacts
-    popdict['layer_keys'] = layer_keys
+        # Actually create the people
+        people = cvppl.People(sim.pars, uid=popdict['uid'], age=popdict['age'], sex=popdict['sex'], contacts=popdict['contacts']) # List for storing the people
 
-    return popdict
+        average_age = sum(popdict['age']/pop_size)
+        sc.printv(f'Created {pop_size} people, average age {average_age:0.2f} years', 2, verbose)
 
+        if save_pop:
+            if popfile is None: # pragma: no cover
+                errormsg = 'Please specify a file to save to using the popfile kwarg'
+                raise FileNotFoundError(errormsg)
+            else:
+                filepath = sc.makefilepath(filename=popfile)
+                cvm.save(filepath, people)
+                if verbose:
+                    print(f'Saved population of type "{pop_type}" with {pop_size:n} people to {filepath}')
 
-def make_random_contacts(pop_size, contacts, overshoot=1.2, dispersion=None):
-    '''
-    Make random static contacts.
-
-    Args:
-        pop_size (int): number of agents to create contacts between (N)
-        contacts (dict): a dictionary with one entry per layer describing the average number of contacts per person for that layer
-        overshoot (float): to avoid needing to take multiple Poisson draws
-        dispersion (float): if not None, use a negative binomial distribution with this dispersion parameter instead of Poisson to make the contacts
-
-    Returns:
-        contacts_list (list): a list of length N, where each entry is a dictionary by layer, and each dictionary entry is the UIDs of the agent's contacts
-        layer_keys (list): a list of layer keys, which is the same as the keys of the input "contacts" dictionary
-    '''
-
-    # Preprocessing
-    pop_size = int(pop_size) # Number of people
-    contacts = sc.dcp(contacts)
-    layer_keys = list(contacts.keys())
-    contacts_list = []
-
-    # Precalculate contacts
-    n_across_layers = np.sum(list(contacts.values()))
-    n_all_contacts  = int(pop_size*n_across_layers*overshoot) # The overshoot is used so we won't run out of contacts if the Poisson draws happen to be higher than the expected value
-    all_contacts    = cvu.choose_r(max_n=pop_size, n=n_all_contacts) # Choose people at random
-    p_counts = {}
-    for lkey in layer_keys:
-        if dispersion is None:
-            p_count = cvu.n_poisson(contacts[lkey], pop_size) # Draw the number of Poisson contacts for this person
-        else:
-            p_count = cvu.n_neg_binomial(rate=contacts[lkey], dispersion=dispersion, n=pop_size) # Or, from a negative binomial
-        p_counts[lkey] = np.array((p_count/2.0).round(), dtype=cvd.default_int)
-
-    # Make contacts
-    count = 0
-    for p in range(pop_size):
-        contact_dict = {}
-        for lkey in layer_keys:
-            n_contacts = p_counts[lkey][p]
-            contact_dict[lkey] = all_contacts[count:count+n_contacts] # Assign people
-            count += n_contacts
-        contacts_list.append(contact_dict)
-
-    return contacts_list, layer_keys
+        return people
 
 
-def make_microstructured_contacts(pop_size, contacts):
-    ''' Create microstructured contacts -- i.e. for households '''
+    def make_randpop(self, sim, use_age_data=True, use_household_data=True, sex_ratio=0.5, microstructure=False):
+        '''
+        Make a random population, with contacts.
 
-    # Preprocessing -- same as above
-    pop_size = int(pop_size) # Number of people
-    contacts = sc.dcp(contacts)
-    contacts.pop('c', None) # Remove community
-    layer_keys = list(contacts.keys())
-    contacts_list = [{c:[] for c in layer_keys} for p in range(pop_size)] # Pre-populate
+        This function returns a "popdict" dictionary, which has the following (required) keys:
 
-    for layer_name, cluster_size in contacts.items():
+            - uid: an array of (usually consecutive) integers of length N, uniquely identifying each agent
+            - age: an array of floats of length N, the age in years of each agent
+            - sex: an array of integers of length N (not currently used, so does not have to be binary)
+            - contacts: list of length N listing the contacts; see make_random_contacts() for details
+            - layer_keys: a list of strings representing the different contact layers in the population; see make_random_contacts() for details
 
-        # Initialize
-        cluster_dict = dict() # Add dictionary for this layer
-        n_remaining = pop_size # Make clusters - each person belongs to one cluster
-        contacts_dict = defaultdict(set) # Use defaultdict of sets for convenience while initializing. Could probably change this as part of performance optimization
+        Args:
+            sim (Sim): the simulation object
+            use_age_data (bool): whether to use location-specific age data
+            use_household_data (bool): whether to use location-specific household size data
+            sex_ratio (float): proportion of the population that is male (not currently used)
+            microstructure (bool): whether or not to use the microstructuring algorithm to group contacts
 
-        # Loop over the clusters
-        cluster_id = -1
-        while n_remaining > 0:
-            cluster_id += 1 # Assign cluster id
-            this_cluster =  cvu.poisson(cluster_size)  # Sample the cluster size
-            if this_cluster > n_remaining:
-                this_cluster = n_remaining
+        Returns:
+            popdict (dict): a dictionary representing the population, with the following keys for a population of N agents with M contacts between them:
+        '''
 
-            # Indices of people in this cluster
-            cluster_indices = (pop_size-n_remaining)+np.arange(this_cluster)
-            cluster_dict[cluster_id] = cluster_indices
-            for i in cluster_indices: # Add symmetric pairwise contacts in each cluster
-                for j in cluster_indices:
-                    if j > i:
-                        contacts_dict[i].add(j)
+        pop_size = int(sim['pop_size']) # Number of people
 
-            n_remaining -= this_cluster
+        # Load age data and household demographics based on 2018 Seattle demographics by default, or country if available
+        age_data = cvd.default_age_data
+        location = sim['location']
+        if location is not None:
+            if sim['verbose']:
+                print(f'Loading location-specific data for "{location}"')
+            if use_age_data:
+                try:
+                    age_data = cvdata.get_age_distribution(location)
+                except ValueError as E:
+                    print(f'Could not load age data for requested location "{location}" ({str(E)}), using default')
+            if use_household_data:
+                try:
+                    household_size = cvdata.get_household_size(location)
+                    if 'h' in sim['contacts']:
+                        sim['contacts']['h'] = household_size - 1 # Subtract 1 because e.g. each person in a 3-person household has 2 contacts
+                    else:
+                        keystr = ', '.join(list(sim['contacts'].keys()))
+                        print(f'Warning; not loading household size for "{location}" since no "h" key; keys are "{keystr}". Try "hybrid" population type?')
+                except ValueError as E:
+                    if sim['verbose']>=2: # These don't exist for many locations, so skip the warning by default
+                        print(f'Could not load household size data for requested location "{location}" ({str(E)}), using default')
 
-        for key in contacts_dict.keys():
-            contacts_list[key][layer_name] = np.array(list(contacts_dict[key]), dtype=cvd.default_int)
+        # Handle sexes and ages
+        uids           = np.arange(pop_size, dtype=cvd.default_int)
+        sexes          = np.random.binomial(1, sex_ratio, pop_size)
+        age_data_min   = age_data[:,0]
+        age_data_max   = age_data[:,1] + 1 # Since actually e.g. 69.999
+        age_data_range = age_data_max - age_data_min
+        age_data_prob  = age_data[:,2]
+        age_data_prob /= age_data_prob.sum() # Ensure it sums to 1
+        age_bins       = cvu.n_multinomial(age_data_prob, pop_size) # Choose age bins
+        ages           = age_data_min[age_bins] + age_data_range[age_bins]*np.random.random(pop_size) # Uniformly distribute within this age bin
 
-        clusters = {layer_name: cluster_dict}
+        # Store output
+        popdict = {}
+        popdict['uid'] = uids
+        popdict['age'] = ages
+        popdict['sex'] = sexes
 
-    return contacts_list, layer_keys, clusters
-
-
-def make_hybrid_contacts(pop_size, ages, contacts, school_ages=None, work_ages=None):
-    '''
-    Create "hybrid" contacts -- microstructured contacts for households and
-    random contacts for schools and workplaces, both of which have extremely
-    basic age structure. A combination of both make_random_contacts() and
-    make_microstructured_contacts().
-    '''
-
-    # Handle inputs and defaults
-    layer_keys = ['h', 's', 'w', 'c']
-    contacts = sc.mergedicts({'h':4, 's':20, 'w':20, 'c':20}, contacts) # Ensure essential keys are populated
-    if school_ages is None:
-        school_ages = [6, 22]
-    if work_ages is None:
-        work_ages   = [22, 65]
-
-    # Create the empty contacts list -- a list of {'h':[], 's':[], 'w':[]}
-    contacts_list = [{key:[] for key in layer_keys} for i in range(pop_size)]
-
-    # Start with the household contacts for each person
-    h_contacts, _, clusters = make_microstructured_contacts(pop_size, {'h':contacts['h']})
-
-    # Make community contacts
-    c_contacts, _ = make_random_contacts(pop_size, {'c':contacts['c']})
-
-    # Get the indices of people in each age bin
-    ages = np.array(ages)
-    s_inds = sc.findinds((ages >= school_ages[0]) * (ages < school_ages[1]))
-    w_inds = sc.findinds((ages >= work_ages[0])   * (ages < work_ages[1]))
-
-    # Create the school and work contacts for each person
-    s_contacts, _ = make_random_contacts(len(s_inds), {'s':contacts['s']})
-    w_contacts, _ = make_random_contacts(len(w_inds), {'w':contacts['w']})
-
-    # Construct the actual lists of contacts
-    for i     in range(pop_size):   contacts_list[i]['h']   =        h_contacts[i]['h']  # Copy over household contacts -- present for everyone
-    for i,ind in enumerate(s_inds): contacts_list[ind]['s'] = s_inds[s_contacts[i]['s']] # Copy over school contacts
-    for i,ind in enumerate(w_inds): contacts_list[ind]['w'] = w_inds[w_contacts[i]['w']] # Copy over work contacts
-    for i     in range(pop_size):   contacts_list[i]['c']   =        c_contacts[i]['c']  # Copy over community contacts -- present for everyone
-
-    return contacts_list, layer_keys, clusters
-
-
-
-def make_synthpop(sim=None, population=None, layer_mapping=None, community_contacts=None, **kwargs):
-    '''
-    Make a population using SynthPops, including contacts. Usually called automatically,
-    but can also be called manually. Either a simulation object or a population must
-    be supplied; if a population is supplied, transform it into the correct format;
-    otherwise, create the population and then transform it.
-
-    Args:
-        sim (Sim): a Covasim simulation object
-        population (list): a pre-generated SynthPops population (otherwise, create a new one)
-        layer_mapping (dict): a custom mapping from SynthPops layers to Covasim layers
-        community_contacts (int): if a simulation is not supplied, create this many community contacts on average
-        kwargs (dict): passed to sp.make_population()
-
-    **Example**::
-
-        sim = cv.Sim(pop_type='synthpops')
-        sim.popdict = cv.make_synthpop(sim)
-        sim.run()
-    '''
-    try:
-        import synthpops as sp # Optional import
-    except ModuleNotFoundError as E: # pragma: no cover
-        errormsg = 'Please install the optional SynthPops module first, e.g. pip install synthpops' # Also caught in make_people()
-        raise ModuleNotFoundError(errormsg) from E
-
-    # Handle layer mapping
-    default_layer_mapping = {'H':'h', 'S':'s', 'W':'w', 'C':'c', 'LTCF':'l'} # Remap keys from old names to new names
-    layer_mapping = sc.mergedicts(default_layer_mapping, layer_mapping)
-
-    # Handle other input arguments
-    if population is None:
-        if sim is None: # pragma: no cover
-            errormsg = 'Either a simulation or a population must be supplied'
-            raise ValueError(errormsg)
-        pop_size = sim['pop_size']
-        population = sp.make_population(n=pop_size, rand_seed=sim['rand_seed'], **kwargs)
-
-    if community_contacts is None:
-        if sim is not None:
-            community_contacts = sim['contacts']['c']
+        # Actually create the contacts
+        if   microstructure == 'random':    contacts, layer_keys    = self.make_random_contacts(pop_size, sim['contacts'])
+        elif microstructure == 'clustered': contacts, layer_keys, _ = self.make_microstructured_contacts(pop_size, sim['contacts'])
+        elif microstructure == 'hybrid':    contacts, layer_keys, _ = self.make_hybrid_contacts(pop_size, ages, sim['contacts'])
         else: # pragma: no cover
-            errormsg = 'If a simulation is not supplied, the number of community contacts must be specified'
-            raise ValueError(errormsg)
+            errormsg = f'Microstructure type "{microstructure}" not found; choices are random, clustered, or hybrid'
+            raise NotImplementedError(errormsg)
 
-    # Create the basic lists
-    pop_size = len(population)
-    uids, ages, sexes, contacts = [], [], [], []
-    for uid,person in population.items():
-        uids.append(uid)
-        ages.append(person['age'])
-        sexes.append(person['sex'])
+        popdict['contacts']   = contacts
+        popdict['layer_keys'] = layer_keys
 
-    # Replace contact UIDs with ints
-    uid_mapping = {uid:u for u,uid in enumerate(uids)}
-    for uid in uids:
-        iid = uid_mapping[uid] # Integer UID
-        person = population.pop(uid)
-        uid_contacts = sc.dcp(person['contacts'])
-        int_contacts = {}
-        for spkey in uid_contacts.keys():
-            try:
-                lkey = layer_mapping[spkey] # Map the SynthPops key into a Covasim layer key
-            except KeyError: # pragma: no cover
-                errormsg = f'Could not find key "{spkey}" in layer mapping "{layer_mapping}"'
-                raise sc.KeyNotFoundError(errormsg)
-            int_contacts[lkey] = []
-            for cid in uid_contacts[spkey]: # Contact ID
-                icid = uid_mapping[cid] # Integer contact ID
-                if icid>iid: # Don't add duplicate contacts
-                    int_contacts[lkey].append(icid)
-            int_contacts[lkey] = np.array(int_contacts[lkey], dtype=cvd.default_int)
-        contacts.append(int_contacts)
+        return popdict
 
-    # Add community contacts
-    c_contacts, _ = make_random_contacts(pop_size, {'c':community_contacts})
-    for i in range(int(pop_size)):
-        contacts[i]['c'] = c_contacts[i]['c'] # Copy over community contacts -- present for everyone
 
-    # Finalize
-    popdict = {}
-    popdict['uid']        = np.array(list(uid_mapping.values()), dtype=cvd.default_int)
-    popdict['age']        = np.array(ages)
-    popdict['sex']        = np.array(sexes)
-    popdict['contacts']   = sc.dcp(contacts)
-    popdict['layer_keys'] = list(layer_mapping.values())
+    def make_random_contacts(self, pop_size, contacts, overshoot=1.2, dispersion=None):
+        '''
+        Make random static contacts.
 
-    return popdict
+        Args:
+            pop_size (int): number of agents to create contacts between (N)
+            contacts (dict): a dictionary with one entry per layer describing the average number of contacts per person for that layer
+            overshoot (float): to avoid needing to take multiple Poisson draws
+            dispersion (float): if not None, use a negative binomial distribution with this dispersion parameter instead of Poisson to make the contacts
+
+        Returns:
+            contacts_list (list): a list of length N, where each entry is a dictionary by layer, and each dictionary entry is the UIDs of the agent's contacts
+            layer_keys (list): a list of layer keys, which is the same as the keys of the input "contacts" dictionary
+        '''
+
+        # Preprocessing
+        pop_size = int(pop_size) # Number of people
+        contacts = sc.dcp(contacts)
+        layer_keys = list(contacts.keys())
+        contacts_list = []
+
+        # Precalculate contacts
+        n_across_layers = np.sum(list(contacts.values()))
+        n_all_contacts  = int(pop_size*n_across_layers*overshoot) # The overshoot is used so we won't run out of contacts if the Poisson draws happen to be higher than the expected value
+        all_contacts    = cvu.choose_r(max_n=pop_size, n=n_all_contacts) # Choose people at random
+        p_counts = {}
+        for lkey in layer_keys:
+            if dispersion is None:
+                p_count = cvu.n_poisson(contacts[lkey], pop_size) # Draw the number of Poisson contacts for this person
+            else:
+                p_count = cvu.n_neg_binomial(rate=contacts[lkey], dispersion=dispersion, n=pop_size) # Or, from a negative binomial
+            p_counts[lkey] = np.array((p_count/2.0).round(), dtype=cvd.default_int)
+
+        # Make contacts
+        count = 0
+        for p in range(pop_size):
+            contact_dict = {}
+            for lkey in layer_keys:
+                n_contacts = p_counts[lkey][p]
+                contact_dict[lkey] = all_contacts[count:count+n_contacts] # Assign people
+                count += n_contacts
+            contacts_list.append(contact_dict)
+
+        return contacts_list, layer_keys
+
+
+    def make_microstructured_contacts(self, pop_size, contacts):
+        ''' Create microstructured contacts -- i.e. for households '''
+
+        # Preprocessing -- same as above
+        pop_size = int(pop_size) # Number of people
+        contacts = sc.dcp(contacts)
+        contacts.pop('c', None) # Remove community
+        layer_keys = list(contacts.keys())
+        contacts_list = [{c:[] for c in layer_keys} for p in range(pop_size)] # Pre-populate
+
+        for layer_name, cluster_size in contacts.items():
+
+            # Initialize
+            cluster_dict = dict() # Add dictionary for this layer
+            n_remaining = pop_size # Make clusters - each person belongs to one cluster
+            contacts_dict = defaultdict(set) # Use defaultdict of sets for convenience while initializing. Could probably change this as part of performance optimization
+
+            # Loop over the clusters
+            cluster_id = -1
+            while n_remaining > 0:
+                cluster_id += 1 # Assign cluster id
+                this_cluster =  cvu.poisson(cluster_size)  # Sample the cluster size
+                if this_cluster > n_remaining:
+                    this_cluster = n_remaining
+
+                # Indices of people in this cluster
+                cluster_indices = (pop_size-n_remaining)+np.arange(this_cluster)
+                cluster_dict[cluster_id] = cluster_indices
+                for i in cluster_indices: # Add symmetric pairwise contacts in each cluster
+                    for j in cluster_indices:
+                        if j > i:
+                            contacts_dict[i].add(j)
+
+                n_remaining -= this_cluster
+
+            for key in contacts_dict.keys():
+                contacts_list[key][layer_name] = np.array(list(contacts_dict[key]), dtype=cvd.default_int)
+
+            clusters = {layer_name: cluster_dict}
+
+        return contacts_list, layer_keys, clusters
+
+
+    def make_hybrid_contacts(self, pop_size, ages, contacts, school_ages=None, work_ages=None):
+        '''
+        Create "hybrid" contacts -- microstructured contacts for households and
+        random contacts for schools and workplaces, both of which have extremely
+        basic age structure. A combination of both make_random_contacts() and
+        make_microstructured_contacts().
+        '''
+
+        # Handle inputs and defaults
+        layer_keys = ['h', 's', 'w', 'c']
+        contacts = sc.mergedicts({'h':4, 's':20, 'w':20, 'c':20}, contacts) # Ensure essential keys are populated
+        if school_ages is None:
+            school_ages = [6, 22]
+        if work_ages is None:
+            work_ages   = [22, 65]
+
+        # Create the empty contacts list -- a list of {'h':[], 's':[], 'w':[]}
+        contacts_list = [{key:[] for key in layer_keys} for i in range(pop_size)]
+
+        # Start with the household contacts for each person
+        h_contacts, _, clusters = self.make_microstructured_contacts(pop_size, {'h':contacts['h']})
+
+        # Make community contacts
+        c_contacts, _ = self.make_random_contacts(pop_size, {'c':contacts['c']})
+
+        # Get the indices of people in each age bin
+        ages = np.array(ages)
+        s_inds = sc.findinds((ages >= school_ages[0]) * (ages < school_ages[1]))
+        w_inds = sc.findinds((ages >= work_ages[0])   * (ages < work_ages[1]))
+
+        # Create the school and work contacts for each person
+        s_contacts, _ = self.make_random_contacts(len(s_inds), {'s':contacts['s']})
+        w_contacts, _ = self.make_random_contacts(len(w_inds), {'w':contacts['w']})
+
+        # Construct the actual lists of contacts
+        for i     in range(pop_size):   contacts_list[i]['h']   =        h_contacts[i]['h']  # Copy over household contacts -- present for everyone
+        for i,ind in enumerate(s_inds): contacts_list[ind]['s'] = s_inds[s_contacts[i]['s']] # Copy over school contacts
+        for i,ind in enumerate(w_inds): contacts_list[ind]['w'] = w_inds[w_contacts[i]['w']] # Copy over work contacts
+        for i     in range(pop_size):   contacts_list[i]['c']   =        c_contacts[i]['c']  # Copy over community contacts -- present for everyone
+
+        return contacts_list, layer_keys, clusters
+
+
+
+    def make_synthpop(self, sim=None, population=None, layer_mapping=None, community_contacts=None, **kwargs):
+        '''
+        Make a population using SynthPops, including contacts. Usually called automatically,
+        but can also be called manually. Either a simulation object or a population must
+        be supplied; if a population is supplied, transform it into the correct format;
+        otherwise, create the population and then transform it.
+
+        Args:
+            sim (Sim): a Covasim simulation object
+            population (list): a pre-generated SynthPops population (otherwise, create a new one)
+            layer_mapping (dict): a custom mapping from SynthPops layers to Covasim layers
+            community_contacts (int): if a simulation is not supplied, create this many community contacts on average
+            kwargs (dict): passed to sp.make_population()
+
+        **Example**::
+
+            sim = cv.Sim(pop_type='synthpops')
+            sim.popdict = cv.make_synthpop(sim)
+            sim.run()
+        '''
+        try:
+            import synthpops as sp # Optional import
+        except ModuleNotFoundError as E: # pragma: no cover
+            errormsg = 'Please install the optional SynthPops module first, e.g. pip install synthpops' # Also caught in make_people()
+            raise ModuleNotFoundError(errormsg) from E
+
+        # Handle layer mapping
+        default_layer_mapping = {'H':'h', 'S':'s', 'W':'w', 'C':'c', 'LTCF':'l'} # Remap keys from old names to new names
+        layer_mapping = sc.mergedicts(default_layer_mapping, layer_mapping)
+
+        # Handle other input arguments
+        if population is None:
+            if sim is None: # pragma: no cover
+                errormsg = 'Either a simulation or a population must be supplied'
+                raise ValueError(errormsg)
+            pop_size = sim['pop_size']
+            population = sp.make_population(n=pop_size, rand_seed=sim['rand_seed'], **kwargs)
+
+        if community_contacts is None:
+            if sim is not None:
+                community_contacts = sim['contacts']['c']
+            else: # pragma: no cover
+                errormsg = 'If a simulation is not supplied, the number of community contacts must be specified'
+                raise ValueError(errormsg)
+
+        # Create the basic lists
+        pop_size = len(population)
+        uids, ages, sexes, contacts = [], [], [], []
+        for uid,person in population.items():
+            uids.append(uid)
+            ages.append(person['age'])
+            sexes.append(person['sex'])
+
+        # Replace contact UIDs with ints
+        uid_mapping = {uid:u for u,uid in enumerate(uids)}
+        for uid in uids:
+            iid = uid_mapping[uid] # Integer UID
+            person = population.pop(uid)
+            uid_contacts = sc.dcp(person['contacts'])
+            int_contacts = {}
+            for spkey in uid_contacts.keys():
+                try:
+                    lkey = layer_mapping[spkey] # Map the SynthPops key into a Covasim layer key
+                except KeyError: # pragma: no cover
+                    errormsg = f'Could not find key "{spkey}" in layer mapping "{layer_mapping}"'
+                    raise sc.KeyNotFoundError(errormsg)
+                int_contacts[lkey] = []
+                for cid in uid_contacts[spkey]: # Contact ID
+                    icid = uid_mapping[cid] # Integer contact ID
+                    if icid>iid: # Don't add duplicate contacts
+                        int_contacts[lkey].append(icid)
+                int_contacts[lkey] = np.array(int_contacts[lkey], dtype=cvd.default_int)
+            contacts.append(int_contacts)
+
+        # Add community contacts
+        c_contacts, _ = self.make_random_contacts(pop_size, {'c':community_contacts})
+        for i in range(int(pop_size)):
+            contacts[i]['c'] = c_contacts[i]['c'] # Copy over community contacts -- present for everyone
+
+        # Finalize
+        popdict = {}
+        popdict['uid']        = np.array(list(uid_mapping.values()), dtype=cvd.default_int)
+        popdict['age']        = np.array(ages)
+        popdict['sex']        = np.array(sexes)
+        popdict['contacts']   = sc.dcp(contacts)
+        popdict['layer_keys'] = list(layer_mapping.values())
+
+        return popdict

--- a/covasim/sim.py
+++ b/covasim/sim.py
@@ -181,7 +181,7 @@ class Sim(cvb.BaseSim):
             pop_keys = set(self.people.contacts.keys())
             if pop_keys != set(layer_keys): # pragma: no cover
                 if not len(pop_keys):
-                    errormsg = f'Your population does not have any layer keys, but your simulation does {layer_keys}. If you called cv.People() directly, you probably need cv.make_people() instead.'
+                    errormsg = f'Your population does not have any layer keys, but your simulation does {layer_keys}. If you called cv.People() directly, you probably need cv.Population.make_people() instead.'
                     raise sc.KeyNotFoundError(errormsg)
                 else:
                     errormsg = f'Please update your parameter keys {layer_keys} to match population keys {pop_keys}. You may find sim.reset_layer_pars() helpful.'
@@ -411,7 +411,7 @@ class Sim(cvb.BaseSim):
             popfile   (str): filename to load/save the population
             reset    (bool): whether to regenerate the people even if they already exist
             verbose   (int): detail to print
-            kwargs   (dict): passed to cv.make_people()
+            kwargs   (dict): passed to cv.Population.make_people()
         '''
 
         # Handle inputs
@@ -422,11 +422,11 @@ class Sim(cvb.BaseSim):
             if self.people:
                 resetstr = ' (resetting people)' if reset else ' (warning: not resetting sim.people)'
             print(f'Initializing sim{resetstr} with {self["pop_size"]:0n} people for {self["n_days"]} days')
-        if load_pop and self.popdict is None: # If there's a popdict, we initialize it via cvpop.make_people()
+        if load_pop and self.popdict is None: # If there's a popdict, we initialize it via cvpop.Population.make_people()
             self.load_population(popfile=popfile)
 
         # Actually make the people
-        self.people = cvpop.make_people(self, save_pop=save_pop, popfile=popfile, reset=reset, verbose=verbose, **kwargs)
+        self.people = cvpop.Population(self, save_pop=save_pop, popfile=popfile, reset=reset, verbose=verbose, **kwargs).people
         self.people.initialize() # Fully initialize the people
 
         # Handle anyone who isn't susceptible

--- a/tests/benchmark.py
+++ b/tests/benchmark.py
@@ -9,11 +9,12 @@ from test_baselines import make_sim
 sim = make_sim(use_defaults=False, do_plot=False) # Use the same sim as from the regression/benchmarking tests
 to_profile = 'step' # Must be one of the options listed below
 
+population = cv.Population(sim)
 func_options = {
-    'make_contacts': cv.make_random_contacts,
-    'make_randpop':  cv.make_randpop,
+    'make_contacts': population.make_random_contacts,
+    'make_randpop':  population.make_randpop,
     'person':        cv.Person.__init__,
-    'make_people':   cv.make_people,
+    'make_people':   population.make_people,
     'init_people':   sim.init_people,
     'initialize':    sim.initialize,
     'run':           sim.run,

--- a/tests/devtests/archive/dev_test_people.py
+++ b/tests/devtests/archive/dev_test_people.py
@@ -19,7 +19,8 @@ sc.toc(label='from people')
 ppl3 = people + ppl2
 
 sim = cv.Sim(pop_type='random', pop_size=20000)
-cv.make_people(sim)
+population = cv.Population(sim)
+population.make_people(sim)
 ppl4 = sim.people
 
 sc.toc(label='as sim')
@@ -39,12 +40,13 @@ sc.toc(label='prognoses')
 
 
 #%% Test contacts creation
-contacts_list, contact_keys = cv.make_random_contacts(100, {'a':10, 'b':20})
+contacts_list, contact_keys = population.make_random_contacts(100, {'a':10, 'b':20})
 
 
 #%% Test layers
 
 sim2 = cv.Sim(pop_type='random', use_layers=True, pop_size=500)
-popdict = cv.make_randpop(sim2, microstructure=sim['pop_type'])
-cv.make_people(sim2)
+population2 = cv.Population(sim2)
+popdict = population2.make_randpop(sim2, microstructure=sim['pop_type'])
+population2.make_people(sim2)
 ppl5 = sim2.people

--- a/tests/devtests/archive/with_alf.py
+++ b/tests/devtests/archive/with_alf.py
@@ -45,6 +45,7 @@ def remove_contacts_from_layer(layer, inds, sim):
 
 sim = cv.Sim(pop_type='hybrid', pop_size=2e4)
 sim.initialize()
+population = cv.Population(sim)
 
 # Set alf parameters to look like household
 for key in ['contacts', 'dynam_layer', 'beta_layer', 'quar_eff']:
@@ -57,7 +58,7 @@ layer_keys = ['alf']
 alf_inds = cv.binomial_filter(alf_prob, sc.findinds(sim.people.age >= min_alf_age))
 assert max(alf_inds) < pop_size
 contacts_list = [{key: [] for key in layer_keys} for i in range(pop_size)]
-alf_contacts, _, clusters = cv.make_microstructured_contacts(len(alf_inds), {'alf': n_alf_contacts})
+alf_contacts, _, clusters = population.make_microstructured_contacts(len(alf_inds), {'alf': n_alf_contacts})
 alf_dict = clusters['alf']
 
 for i, ind in enumerate(alf_inds):

--- a/tests/devtests/layer_key_tests.py
+++ b/tests/devtests/layer_key_tests.py
@@ -56,7 +56,8 @@ ssp.run()
 
 sc.heading('SynthPops + LTCF test')
 sf = cv.Sim(pop_size=2000, pop_type='synthpops')
-sf.popdict = cv.make_synthpop(sf, with_facilities=True, layer_mapping={'LTCF':'f'})
+population = cv.Population(sf)
+sf.popdict = population.make_synthpop(sf, with_facilities=True, layer_mapping={'LTCF':'f'})
 cv.save('synth.pop', sf.popdict)
 with pytest.raises(sc.KeyNotFoundError): # Layer key mismatch, f is not initialized
     sf.run()

--- a/tests/devtests/synthpops_options.py
+++ b/tests/devtests/synthpops_options.py
@@ -10,7 +10,8 @@ which = ['simple', 'complex'][1]
 if which == 'simple':
 
     sim = cv.Sim(pop_size=5000, pop_type='synthpops')
-    sim.popdict = cv.make_synthpop(sim, with_facilities=True, layer_mapping={'LTCF':'f'})
+    population = cv.Population(sim)
+    sim.popdict = population.make_synthpop(sim, with_facilities=True, layer_mapping={'LTCF':'f'})
     sim.reset_layer_pars()
     sim.run()
 
@@ -27,7 +28,8 @@ else:
     for ltcf in [False, True]:
         print(f'Running LTCF {ltcf}')
         sim = cv.Sim(pars)
-        sim.popdict = cv.make_synthpop(sim, with_facilities=ltcf, layer_mapping={'LTCF':'f'})
+        population = cv.Population(sim)
+        sim.popdict = population.make_synthpop(sim, with_facilities=ltcf, layer_mapping={'LTCF':'f'})
         sim.reset_layer_pars()
         sims.append(sim)
 

--- a/tests/devtests/test_variants.py
+++ b/tests/devtests/test_variants.py
@@ -145,7 +145,8 @@ def test_vaccine_1dose(do_plot=False, do_show=True, do_save=False):
 
 def test_synthpops():
     sim = cv.Sim(use_waning=True, **sc.mergedicts(base_pars, dict(pop_size=5000, pop_type='synthpops')))
-    sim.popdict = cv.make_synthpop(sim, with_facilities=True, layer_mapping={'LTCF': 'f'})
+    population = cv.Population(sim)
+    sim.popdict = population.make_synthpop(sim, with_facilities=True, layer_mapping={'LTCF': 'f'})
     sim.reset_layer_pars()
 
     # Vaccinate 75+, then 65+, then 50+, then 18+ on days 20, 40, 60, 80


### PR DESCRIPTION
Please note: this PR is part of a school project.

### Why?

Covasim must instantiate and manage a population of people, where the people are from the module `people.py`. The module `population.py` serves this purpose, but it consists of a number of functions in the module that are called directly by the user when initializing the Covasim simulation. 

In choosing an aggregate, we observe a sort of “has-a” relationship between a population (which is initialized with certain demographic patterns) and the people within it; a person can belong to a population group, but their lifecycle is not bound to it. This is the foundation for an aggregate `Population`.

### Description of Changes

This PR implements a `Population` aggregate in `population.py`, creating a `Population` class responsible for generating a population of `People`. Now, the `Population` aggregate can be instantiated with given parameters, and the `people` are stored as a field. For example, in the `Sim` class in `sim.py`, the initialization of people in `init_people` now creates the `Population` aggregate and accesses the people through the aggregate root, the `people` field.