### PR TITLE
Apply aggregation in population.py

### DIFF
--- a/covasim/population.py
+++ b/covasim/population.py
@@ -2,8 +2,8 @@
 Defines functions for making the population.
 '''
 
-#%% Imports
-import numpy as np # Needed for a few things not provided by pl
+# %% Imports
+import numpy as np  # Needed for a few things not provided by pl
 import sciris as sc
 from collections import defaultdict
 from . import requirements as cvreq
@@ -21,299 +21,345 @@ __all__ = ['make_people', 'make_randpop', 'make_random_contacts',
            'make_synthpop']
 
 
-def make_people(sim, popdict=None, save_pop=False, popfile=None, die=True, reset=False, verbose=None, **kwargs):
-    '''
-    Make the actual people for the simulation. Usually called via sim.initialize(),
-    but can be called directly by the user.
+class population():
+    def make_people(self, sim, popdict=None, save_pop=False, popfile=None, die=True, reset=False, verbose=None, **kwargs):
+        '''
+        Make the actual people for the simulation. Usually called via sim.initialize(),
+        but can be called directly by the user.
 
-    Args:
-        sim      (Sim)  : the simulation object; population parameters are taken from the sim object
-        popdict  (dict) : if supplied, use this population dictionary instead of generating a new one
-        save_pop (bool) : whether to save the population to disk
-        popfile  (bool) : if so, the filename to save to
-        die      (bool) : whether or not to fail if synthetic populations are requested but not available
-        reset    (bool) : whether to force population creation even if self.popdict/self.people exists
-        verbose  (bool) : level of detail to print
-        kwargs   (dict) : passed to make_randpop() or make_synthpop()
+        Args:
+            sim      (Sim)  : the simulation object; population parameters are taken from the sim object
+            popdict  (dict) : if supplied, use this population dictionary instead of generating a new one
+            save_pop (bool) : whether to save the population to disk
+            popfile  (bool) : if so, the filename to save to
+            die      (bool) : whether or not to fail if synthetic populations are requested but not available
+            reset    (bool) : whether to force population creation even if self.popdict/self.people exists
+            verbose  (bool) : level of detail to print
+            kwargs   (dict) : passed to make_randpop() or make_synthpop()
 
-    Returns:
-        people (People): people
-    '''
+        Returns:
+            people (People): people
+        '''
 
-    # Set inputs and defaults
-    pop_size = int(sim['pop_size']) # Shorten
-    pop_type = sim['pop_type'] # Shorten
-    if verbose is None:
-        verbose = sim['verbose']
-    if popfile is None:
-        popfile = sim.popfile
+        # Set inputs and defaults
+        pop_size = int(sim['pop_size'])  # Shorten
+        pop_type = sim['pop_type']  # Shorten
+        if verbose is None:
+            verbose = sim['verbose']
+        if popfile is None:
+            popfile = sim.popfile
 
-    # Check which type of population to produce
-    if pop_type == 'synthpops':
-        if not cvreq.check_synthpops(): # pragma: no cover
-            errormsg = f'You have requested "{pop_type}" population, but synthpops is not available; please use random, clustered, or hybrid'
-            if die:
-                raise ValueError(errormsg)
-            else:
-                print(errormsg)
-                pop_type = 'random'
-
-        location = sim['location']
-        if location: # pragma: no cover
-            print(f'Warning: not setting ages or contacts for "{location}" since synthpops contacts are pre-generated')
-
-    # Actually create the population
-    if sim.people and not reset:
-        return sim.people # If it's already there, just return
-    elif sim.popdict and not reset:
-        popdict = sim.popdict # Use stored one
-        sim.popdict = None # Once loaded, remove
-    elif popdict is None: # Main use case: no popdict is supplied
-        # Create the population
-        if pop_type in ['random', 'clustered', 'hybrid']:
-            popdict = make_randpop(sim, microstructure=pop_type, **kwargs)
-        elif pop_type == 'synthpops':
-            popdict = make_synthpop(sim, **kwargs)
-        elif pop_type is None: # pragma: no cover
-            errormsg = 'You have set pop_type=None. This is fine, but you must ensure sim.popdict exists before calling make_people().'
-            raise ValueError(errormsg)
-        else: # pragma: no cover
-            errormsg = f'Population type "{pop_type}" not found; choices are random, clustered, hybrid, or synthpops'
-            raise ValueError(errormsg)
-
-    # Ensure prognoses are set
-    if sim['prognoses'] is None:
-        sim['prognoses'] = cvpar.get_prognoses(sim['prog_by_age'], version=sim._default_ver)
-
-    # Actually create the people
-    people = cvppl.People(sim.pars, uid=popdict['uid'], age=popdict['age'], sex=popdict['sex'], contacts=popdict['contacts']) # List for storing the people
-
-    average_age = sum(popdict['age']/pop_size)
-    sc.printv(f'Created {pop_size} people, average age {average_age:0.2f} years', 2, verbose)
-
-    if save_pop:
-        if popfile is None: # pragma: no cover
-            errormsg = 'Please specify a file to save to using the popfile kwarg'
-            raise FileNotFoundError(errormsg)
-        else:
-            filepath = sc.makefilepath(filename=popfile)
-            cvm.save(filepath, people)
-            if verbose:
-                print(f'Saved population of type "{pop_type}" with {pop_size:n} people to {filepath}')
-
-    return people
-
-
-def make_randpop(sim, use_age_data=True, use_household_data=True, sex_ratio=0.5, microstructure=False):
-    '''
-    Make a random population, with contacts.
-
-    This function returns a "popdict" dictionary, which has the following (required) keys:
-
-        - uid: an array of (usually consecutive) integers of length N, uniquely identifying each agent
-        - age: an array of floats of length N, the age in years of each agent
-        - sex: an array of integers of length N (not currently used, so does not have to be binary)
-        - contacts: list of length N listing the contacts; see make_random_contacts() for details
-        - layer_keys: a list of strings representing the different contact layers in the population; see make_random_contacts() for details
-
-    Args:
-        sim (Sim): the simulation object
-        use_age_data (bool): whether to use location-specific age data
-        use_household_data (bool): whether to use location-specific household size data
-        sex_ratio (float): proportion of the population that is male (not currently used)
-        microstructure (bool): whether or not to use the microstructuring algorithm to group contacts
-
-    Returns:
-        popdict (dict): a dictionary representing the population, with the following keys for a population of N agents with M contacts between them:
-    '''
-
-    pop_size = int(sim['pop_size']) # Number of people
-
-    # Load age data and household demographics based on 2018 Seattle demographics by default, or country if available
-    age_data = cvd.default_age_data
-    location = sim['location']
-    if location is not None:
-        if sim['verbose']:
-            print(f'Loading location-specific data for "{location}"')
-        if use_age_data:
-            try:
-                age_data = cvdata.get_age_distribution(location)
-            except ValueError as E:
-                print(f'Could not load age data for requested location "{location}" ({str(E)}), using default')
-        if use_household_data:
-            try:
-                household_size = cvdata.get_household_size(location)
-                if 'h' in sim['contacts']:
-                    sim['contacts']['h'] = household_size - 1 # Subtract 1 because e.g. each person in a 3-person household has 2 contacts
+        # Check which type of population to produce
+        if pop_type == 'synthpops':
+            if not cvreq.check_synthpops():  # pragma: no cover
+                errormsg = f'You have requested "{pop_type}" population, but synthpops is not available; please use random, clustered, or hybrid'
+                if die:
+                    raise ValueError(errormsg)
                 else:
-                    keystr = ', '.join(list(sim['contacts'].keys()))
-                    print(f'Warning; not loading household size for "{location}" since no "h" key; keys are "{keystr}". Try "hybrid" population type?')
-            except ValueError as E:
-                if sim['verbose']>=2: # These don't exist for many locations, so skip the warning by default
-                    print(f'Could not load household size data for requested location "{location}" ({str(E)}), using default')
+                    print(errormsg)
+                    pop_type = 'random'
 
-    # Handle sexes and ages
-    uids           = np.arange(pop_size, dtype=cvd.default_int)
-    sexes          = np.random.binomial(1, sex_ratio, pop_size)
-    age_data_min   = age_data[:,0]
-    age_data_max   = age_data[:,1] + 1 # Since actually e.g. 69.999
-    age_data_range = age_data_max - age_data_min
-    age_data_prob  = age_data[:,2]
-    age_data_prob /= age_data_prob.sum() # Ensure it sums to 1
-    age_bins       = cvu.n_multinomial(age_data_prob, pop_size) # Choose age bins
-    ages           = age_data_min[age_bins] + age_data_range[age_bins]*np.random.random(pop_size) # Uniformly distribute within this age bin
+            location = sim['location']
+            if location:  # pragma: no cover
+                print(
+                    f'Warning: not setting ages or contacts for "{location}" since synthpops contacts are pre-generated')
 
-    # Store output
-    popdict = {}
-    popdict['uid'] = uids
-    popdict['age'] = ages
-    popdict['sex'] = sexes
+        # Actually create the population
+        if sim.people and not reset:
+            return sim.people  # If it's already there, just return
+        elif sim.popdict and not reset:
+            popdict = sim.popdict  # Use stored one
+            sim.popdict = None  # Once loaded, remove
+        elif popdict is None:  # Main use case: no popdict is supplied
+            # Create the population
+            if pop_type in ['random', 'clustered', 'hybrid']:
+                popdict = self.make_randpop(
+                    sim, microstructure=pop_type, **kwargs)
+            elif pop_type == 'synthpops':
+                popdict = make_synthpop(sim, **kwargs)
+            elif pop_type is None:  # pragma: no cover
+                errormsg = 'You have set pop_type=None. This is fine, but you must ensure sim.popdict exists before calling make_people().'
+                raise ValueError(errormsg)
+            else:  # pragma: no cover
+                errormsg = f'Population type "{pop_type}" not found; choices are random, clustered, hybrid, or synthpops'
+                raise ValueError(errormsg)
 
-    # Actually create the contacts
-    if   microstructure == 'random':    contacts, layer_keys    = make_random_contacts(pop_size, sim['contacts'])
-    elif microstructure == 'clustered': contacts, layer_keys, _ = make_microstructured_contacts(pop_size, sim['contacts'])
-    elif microstructure == 'hybrid':    contacts, layer_keys, _ = make_hybrid_contacts(pop_size, ages, sim['contacts'])
-    else: # pragma: no cover
-        errormsg = f'Microstructure type "{microstructure}" not found; choices are random, clustered, or hybrid'
-        raise NotImplementedError(errormsg)
+        # Ensure prognoses are set
+        if sim['prognoses'] is None:
+            sim['prognoses'] = cvpar.get_prognoses(
+                sim['prog_by_age'], version=sim._default_ver)
 
-    popdict['contacts']   = contacts
-    popdict['layer_keys'] = layer_keys
+        # Actually create the people
+        # List for storing the people
+        people = cvppl.People(
+            sim.pars, uid=popdict['uid'], age=popdict['age'], sex=popdict['sex'], contacts=popdict['contacts'])
 
-    return popdict
+        average_age = sum(popdict['age']/pop_size)
+        sc.printv(
+            f'Created {pop_size} people, average age {average_age:0.2f} years', 2, verbose)
+
+        if save_pop:
+            if popfile is None:  # pragma: no cover
+                errormsg = 'Please specify a file to save to using the popfile kwarg'
+                raise FileNotFoundError(errormsg)
+            else:
+                filepath = sc.makefilepath(filename=popfile)
+                cvm.save(filepath, people)
+                if verbose:
+                    print(
+                        f'Saved population of type "{pop_type}" with {pop_size:n} people to {filepath}')
+
+        return people
+
+    def make_randpop(self, sim, use_age_data=True, use_household_data=True, sex_ratio=0.5, microstructure=False):
+        '''
+        Make a random population, with contacts.
+
+        This function returns a "popdict" dictionary, which has the following (required) keys:
+
+            - uid: an array of (usually consecutive) integers of length N, uniquely identifying each agent
+            - age: an array of floats of length N, the age in years of each agent
+            - sex: an array of integers of length N (not currently used, so does not have to be binary)
+            - contacts: list of length N listing the contacts; see make_random_contacts() for details
+            - layer_keys: a list of strings representing the different contact layers in the population; see make_random_contacts() for details
+
+        Args:
+            sim (Sim): the simulation object
+            use_age_data (bool): whether to use location-specific age data
+            use_household_data (bool): whether to use location-specific household size data
+            sex_ratio (float): proportion of the population that is male (not currently used)
+            microstructure (bool): whether or not to use the microstructuring algorithm to group contacts
+
+        Returns:
+            popdict (dict): a dictionary representing the population, with the following keys for a population of N agents with M contacts between them:
+        '''
+
+        pop_size = int(sim['pop_size'])  # Number of people
+
+        # Load age data and household demographics based on 2018 Seattle demographics by default, or country if available
+        age_data = cvd.default_age_data
+        location = sim['location']
+        if location is not None:
+            if sim['verbose']:
+                print(f'Loading location-specific data for "{location}"')
+            if use_age_data:
+                try:
+                    age_data = cvdata.get_age_distribution(location)
+                except ValueError as E:
+                    print(
+                        f'Could not load age data for requested location "{location}" ({str(E)}), using default')
+            if use_household_data:
+                try:
+                    household_size = cvdata.get_household_size(location)
+                    if 'h' in sim['contacts']:
+                        # Subtract 1 because e.g. each person in a 3-person household has 2 contacts
+                        sim['contacts']['h'] = household_size - 1
+                    else:
+                        keystr = ', '.join(list(sim['contacts'].keys()))
+                        print(
+                            f'Warning; not loading household size for "{location}" since no "h" key; keys are "{keystr}". Try "hybrid" population type?')
+                except ValueError as E:
+                    # These don't exist for many locations, so skip the warning by default
+                    if sim['verbose'] >= 2:
+                        print(
+                            f'Could not load household size data for requested location "{location}" ({str(E)}), using default')
+
+        # Handle sexes and ages
+        uids = np.arange(pop_size, dtype=cvd.default_int)
+        sexes = np.random.binomial(1, sex_ratio, pop_size)
+        age_data_min = age_data[:, 0]
+        age_data_max = age_data[:, 1] + 1  # Since actually e.g. 69.999
+        age_data_range = age_data_max - age_data_min
+        age_data_prob = age_data[:, 2]
+        age_data_prob /= age_data_prob.sum()  # Ensure it sums to 1
+        age_bins = cvu.n_multinomial(
+            age_data_prob, pop_size)  # Choose age bins
+        # Uniformly distribute within this age bin
+        ages = age_data_min[age_bins] + \
+            age_data_range[age_bins]*np.random.random(pop_size)
+
+        # Store output
+        popdict = {}
+        popdict['uid'] = uids
+        popdict['age'] = ages
+        popdict['sex'] = sexes
+
+        # Actually create the contacts
+        if microstructure == 'random':
+            contacts, layer_keys = self.make_random_contacts(
+                pop_size, sim['contacts'])
+        elif microstructure == 'clustered':
+            contacts, layer_keys, _ = self.make_microstructured_contacts(
+                pop_size, sim['contacts'])
+        elif microstructure == 'hybrid':
+            contacts, layer_keys, _ = self.make_hybrid_contacts(
+                pop_size, ages, sim['contacts'])
+        else:  # pragma: no cover
+            errormsg = f'Microstructure type "{microstructure}" not found; choices are random, clustered, or hybrid'
+            raise NotImplementedError(errormsg)
+
+        popdict['contacts'] = contacts
+        popdict['layer_keys'] = layer_keys
+
+        return popdict
 
 
-def make_random_contacts(pop_size, contacts, overshoot=1.2, dispersion=None):
-    '''
-    Make random static contacts.
+class contacts():
+    def make_random_contacts(pop_size, contacts, overshoot=1.2, dispersion=None):
+        '''
+        Make random static contacts.
 
-    Args:
-        pop_size (int): number of agents to create contacts between (N)
-        contacts (dict): a dictionary with one entry per layer describing the average number of contacts per person for that layer
-        overshoot (float): to avoid needing to take multiple Poisson draws
-        dispersion (float): if not None, use a negative binomial distribution with this dispersion parameter instead of Poisson to make the contacts
+        Args:
+            pop_size (int): number of agents to create contacts between (N)
+            contacts (dict): a dictionary with one entry per layer describing the average number of contacts per person for that layer
+            overshoot (float): to avoid needing to take multiple Poisson draws
+            dispersion (float): if not None, use a negative binomial distribution with this dispersion parameter instead of Poisson to make the contacts
 
-    Returns:
-        contacts_list (list): a list of length N, where each entry is a dictionary by layer, and each dictionary entry is the UIDs of the agent's contacts
-        layer_keys (list): a list of layer keys, which is the same as the keys of the input "contacts" dictionary
-    '''
+        Returns:
+            contacts_list (list): a list of length N, where each entry is a dictionary by layer, and each dictionary entry is the UIDs of the agent's contacts
+            layer_keys (list): a list of layer keys, which is the same as the keys of the input "contacts" dictionary
+        '''
 
-    # Preprocessing
-    pop_size = int(pop_size) # Number of people
-    contacts = sc.dcp(contacts)
-    layer_keys = list(contacts.keys())
-    contacts_list = []
+        # Preprocessing
+        pop_size = int(pop_size)  # Number of people
+        contacts = sc.dcp(contacts)
+        layer_keys = list(contacts.keys())
+        contacts_list = []
 
-    # Precalculate contacts
-    n_across_layers = np.sum(list(contacts.values()))
-    n_all_contacts  = int(pop_size*n_across_layers*overshoot) # The overshoot is used so we won't run out of contacts if the Poisson draws happen to be higher than the expected value
-    all_contacts    = cvu.choose_r(max_n=pop_size, n=n_all_contacts) # Choose people at random
-    p_counts = {}
-    for lkey in layer_keys:
-        if dispersion is None:
-            p_count = cvu.n_poisson(contacts[lkey], pop_size) # Draw the number of Poisson contacts for this person
-        else:
-            p_count = cvu.n_neg_binomial(rate=contacts[lkey], dispersion=dispersion, n=pop_size) # Or, from a negative binomial
-        p_counts[lkey] = np.array((p_count/2.0).round(), dtype=cvd.default_int)
-
-    # Make contacts
-    count = 0
-    for p in range(pop_size):
-        contact_dict = {}
+        # Precalculate contacts
+        n_across_layers = np.sum(list(contacts.values()))
+        # The overshoot is used so we won't run out of contacts if the Poisson draws happen to be higher than the expected value
+        n_all_contacts = int(pop_size*n_across_layers*overshoot)
+        # Choose people at random
+        all_contacts = cvu.choose_r(max_n=pop_size, n=n_all_contacts)
+        p_counts = {}
         for lkey in layer_keys:
-            n_contacts = p_counts[lkey][p]
-            contact_dict[lkey] = all_contacts[count:count+n_contacts] # Assign people
-            count += n_contacts
-        contacts_list.append(contact_dict)
+            if dispersion is None:
+                # Draw the number of Poisson contacts for this person
+                p_count = cvu.n_poisson(contacts[lkey], pop_size)
+            else:
+                # Or, from a negative binomial
+                p_count = cvu.n_neg_binomial(
+                    rate=contacts[lkey], dispersion=dispersion, n=pop_size)
+            p_counts[lkey] = np.array(
+                (p_count/2.0).round(), dtype=cvd.default_int)
 
-    return contacts_list, layer_keys
+        # Make contacts
+        count = 0
+        for p in range(pop_size):
+            contact_dict = {}
+            for lkey in layer_keys:
+                n_contacts = p_counts[lkey][p]
+                contact_dict[lkey] = all_contacts[count:count +
+                                                  n_contacts]  # Assign people
+                count += n_contacts
+            contacts_list.append(contact_dict)
 
+        return contacts_list, layer_keys
 
-def make_microstructured_contacts(pop_size, contacts):
-    ''' Create microstructured contacts -- i.e. for households '''
+    def make_microstructured_contacts(pop_size, contacts):
+        ''' Create microstructured contacts -- i.e. for households '''
 
-    # Preprocessing -- same as above
-    pop_size = int(pop_size) # Number of people
-    contacts = sc.dcp(contacts)
-    contacts.pop('c', None) # Remove community
-    layer_keys = list(contacts.keys())
-    contacts_list = [{c:[] for c in layer_keys} for p in range(pop_size)] # Pre-populate
+        # Preprocessing -- same as above
+        pop_size = int(pop_size)  # Number of people
+        contacts = sc.dcp(contacts)
+        contacts.pop('c', None)  # Remove community
+        layer_keys = list(contacts.keys())
+        contacts_list = [{c: [] for c in layer_keys}
+                         for p in range(pop_size)]  # Pre-populate
 
-    for layer_name, cluster_size in contacts.items():
+        for layer_name, cluster_size in contacts.items():
 
-        # Initialize
-        cluster_dict = dict() # Add dictionary for this layer
-        n_remaining = pop_size # Make clusters - each person belongs to one cluster
-        contacts_dict = defaultdict(set) # Use defaultdict of sets for convenience while initializing. Could probably change this as part of performance optimization
+            # Initialize
+            cluster_dict = dict()  # Add dictionary for this layer
+            n_remaining = pop_size  # Make clusters - each person belongs to one cluster
+            # Use defaultdict of sets for convenience while initializing. Could probably change this as part of performance optimization
+            contacts_dict = defaultdict(set)
 
-        # Loop over the clusters
-        cluster_id = -1
-        while n_remaining > 0:
-            cluster_id += 1 # Assign cluster id
-            this_cluster =  cvu.poisson(cluster_size)  # Sample the cluster size
-            if this_cluster > n_remaining:
-                this_cluster = n_remaining
+            # Loop over the clusters
+            cluster_id = -1
+            while n_remaining > 0:
+                cluster_id += 1  # Assign cluster id
+                # Sample the cluster size
+                this_cluster = cvu.poisson(cluster_size)
+                if this_cluster > n_remaining:
+                    this_cluster = n_remaining
 
-            # Indices of people in this cluster
-            cluster_indices = (pop_size-n_remaining)+np.arange(this_cluster)
-            cluster_dict[cluster_id] = cluster_indices
-            for i in cluster_indices: # Add symmetric pairwise contacts in each cluster
-                for j in cluster_indices:
-                    if j > i:
-                        contacts_dict[i].add(j)
+                # Indices of people in this cluster
+                cluster_indices = (pop_size-n_remaining) + \
+                    np.arange(this_cluster)
+                cluster_dict[cluster_id] = cluster_indices
+                for i in cluster_indices:  # Add symmetric pairwise contacts in each cluster
+                    for j in cluster_indices:
+                        if j > i:
+                            contacts_dict[i].add(j)
 
-            n_remaining -= this_cluster
+                n_remaining -= this_cluster
 
-        for key in contacts_dict.keys():
-            contacts_list[key][layer_name] = np.array(list(contacts_dict[key]), dtype=cvd.default_int)
+            for key in contacts_dict.keys():
+                contacts_list[key][layer_name] = np.array(
+                    list(contacts_dict[key]), dtype=cvd.default_int)
 
-        clusters = {layer_name: cluster_dict}
+            clusters = {layer_name: cluster_dict}
 
-    return contacts_list, layer_keys, clusters
+        return contacts_list, layer_keys, clusters
 
+    def make_hybrid_contacts(self, pop_size, ages, contacts, school_ages=None, work_ages=None):
+        '''
+        Create "hybrid" contacts -- microstructured contacts for households and
+        random contacts for schools and workplaces, both of which have extremely
+        basic age structure. A combination of both make_random_contacts() and
+        make_microstructured_contacts().
+        '''
 
-def make_hybrid_contacts(pop_size, ages, contacts, school_ages=None, work_ages=None):
-    '''
-    Create "hybrid" contacts -- microstructured contacts for households and
-    random contacts for schools and workplaces, both of which have extremely
-    basic age structure. A combination of both make_random_contacts() and
-    make_microstructured_contacts().
-    '''
+        # Handle inputs and defaults
+        layer_keys = ['h', 's', 'w', 'c']
+        # Ensure essential keys are populated
+        contacts = sc.mergedicts({'h': 4, 's': 20, 'w': 20, 'c': 20}, contacts)
+        if school_ages is None:
+            school_ages = [6, 22]
+        if work_ages is None:
+            work_ages = [22, 65]
 
-    # Handle inputs and defaults
-    layer_keys = ['h', 's', 'w', 'c']
-    contacts = sc.mergedicts({'h':4, 's':20, 'w':20, 'c':20}, contacts) # Ensure essential keys are populated
-    if school_ages is None:
-        school_ages = [6, 22]
-    if work_ages is None:
-        work_ages   = [22, 65]
+        # Create the empty contacts list -- a list of {'h':[], 's':[], 'w':[]}
+        contacts_list = [{key: [] for key in layer_keys}
+                         for i in range(pop_size)]
 
-    # Create the empty contacts list -- a list of {'h':[], 's':[], 'w':[]}
-    contacts_list = [{key:[] for key in layer_keys} for i in range(pop_size)]
+        # Start with the household contacts for each person
+        h_contacts, _, clusters = self.make_microstructured_contacts(
+            pop_size, {'h': contacts['h']})
 
-    # Start with the household contacts for each person
-    h_contacts, _, clusters = make_microstructured_contacts(pop_size, {'h':contacts['h']})
+        # Make community contacts
+        c_contacts, _ = self.make_random_contacts(
+            pop_size, {'c': contacts['c']})
 
-    # Make community contacts
-    c_contacts, _ = make_random_contacts(pop_size, {'c':contacts['c']})
+        # Get the indices of people in each age bin
+        ages = np.array(ages)
+        s_inds = sc.findinds(
+            (ages >= school_ages[0]) * (ages < school_ages[1]))
+        w_inds = sc.findinds((ages >= work_ages[0]) * (ages < work_ages[1]))
 
-    # Get the indices of people in each age bin
-    ages = np.array(ages)
-    s_inds = sc.findinds((ages >= school_ages[0]) * (ages < school_ages[1]))
-    w_inds = sc.findinds((ages >= work_ages[0])   * (ages < work_ages[1]))
+        # Create the school and work contacts for each person
+        s_contacts, _ = self.make_random_contacts(
+            len(s_inds), {'s': contacts['s']})
+        w_contacts, _ = self.make_random_contacts(
+            len(w_inds), {'w': contacts['w']})
 
-    # Create the school and work contacts for each person
-    s_contacts, _ = make_random_contacts(len(s_inds), {'s':contacts['s']})
-    w_contacts, _ = make_random_contacts(len(w_inds), {'w':contacts['w']})
+        # Construct the actual lists of contacts
+        for i in range(pop_size):
+            # Copy over household contacts -- present for everyone
+            contacts_list[i]['h'] = h_contacts[i]['h']
+        for i, ind in enumerate(s_inds):
+            # Copy over school contacts
+            contacts_list[ind]['s'] = s_inds[s_contacts[i]['s']]
+        for i, ind in enumerate(w_inds):
+            # Copy over work contacts
+            contacts_list[ind]['w'] = w_inds[w_contacts[i]['w']]
+        for i in range(pop_size):
+            # Copy over community contacts -- present for everyone
+            contacts_list[i]['c'] = c_contacts[i]['c']
 
-    # Construct the actual lists of contacts
-    for i     in range(pop_size):   contacts_list[i]['h']   =        h_contacts[i]['h']  # Copy over household contacts -- present for everyone
-    for i,ind in enumerate(s_inds): contacts_list[ind]['s'] = s_inds[s_contacts[i]['s']] # Copy over school contacts
-    for i,ind in enumerate(w_inds): contacts_list[ind]['w'] = w_inds[w_contacts[i]['w']] # Copy over work contacts
-    for i     in range(pop_size):   contacts_list[i]['c']   =        c_contacts[i]['c']  # Copy over community contacts -- present for everyone
-
-    return contacts_list, layer_keys, clusters
-
+        return contacts_list, layer_keys, clusters
 
 
 def make_synthpop(sim=None, population=None, layer_mapping=None, community_contacts=None, **kwargs):
@@ -337,70 +383,79 @@ def make_synthpop(sim=None, population=None, layer_mapping=None, community_conta
         sim.run()
     '''
     try:
-        import synthpops as sp # Optional import
-    except ModuleNotFoundError as E: # pragma: no cover
-        errormsg = 'Please install the optional SynthPops module first, e.g. pip install synthpops' # Also caught in make_people()
+        import synthpops as sp  # Optional import
+    except ModuleNotFoundError as E:  # pragma: no cover
+        # Also caught in make_people()
+        errormsg = 'Please install the optional SynthPops module first, e.g. pip install synthpops'
         raise ModuleNotFoundError(errormsg) from E
 
     # Handle layer mapping
-    default_layer_mapping = {'H':'h', 'S':'s', 'W':'w', 'C':'c', 'LTCF':'l'} # Remap keys from old names to new names
+    # Remap keys from old names to new names
+    default_layer_mapping = {'H': 'h', 'S': 's',
+                             'W': 'w', 'C': 'c', 'LTCF': 'l'}
     layer_mapping = sc.mergedicts(default_layer_mapping, layer_mapping)
 
     # Handle other input arguments
     if population is None:
-        if sim is None: # pragma: no cover
+        if sim is None:  # pragma: no cover
             errormsg = 'Either a simulation or a population must be supplied'
             raise ValueError(errormsg)
         pop_size = sim['pop_size']
-        population = sp.make_population(n=pop_size, rand_seed=sim['rand_seed'], **kwargs)
+        population = sp.make_population(
+            n=pop_size, rand_seed=sim['rand_seed'], **kwargs)
 
     if community_contacts is None:
         if sim is not None:
             community_contacts = sim['contacts']['c']
-        else: # pragma: no cover
+        else:  # pragma: no cover
             errormsg = 'If a simulation is not supplied, the number of community contacts must be specified'
             raise ValueError(errormsg)
 
     # Create the basic lists
     pop_size = len(population)
     uids, ages, sexes, contacts = [], [], [], []
-    for uid,person in population.items():
+    for uid, person in population.items():
         uids.append(uid)
         ages.append(person['age'])
         sexes.append(person['sex'])
 
     # Replace contact UIDs with ints
-    uid_mapping = {uid:u for u,uid in enumerate(uids)}
+    uid_mapping = {uid: u for u, uid in enumerate(uids)}
     for uid in uids:
-        iid = uid_mapping[uid] # Integer UID
+        iid = uid_mapping[uid]  # Integer UID
         person = population.pop(uid)
         uid_contacts = sc.dcp(person['contacts'])
         int_contacts = {}
         for spkey in uid_contacts.keys():
             try:
-                lkey = layer_mapping[spkey] # Map the SynthPops key into a Covasim layer key
-            except KeyError: # pragma: no cover
+                # Map the SynthPops key into a Covasim layer key
+                lkey = layer_mapping[spkey]
+            except KeyError:  # pragma: no cover
                 errormsg = f'Could not find key "{spkey}" in layer mapping "{layer_mapping}"'
                 raise sc.KeyNotFoundError(errormsg)
             int_contacts[lkey] = []
-            for cid in uid_contacts[spkey]: # Contact ID
-                icid = uid_mapping[cid] # Integer contact ID
-                if icid>iid: # Don't add duplicate contacts
+            for cid in uid_contacts[spkey]:  # Contact ID
+                icid = uid_mapping[cid]  # Integer contact ID
+                if icid > iid:  # Don't add duplicate contacts
                     int_contacts[lkey].append(icid)
-            int_contacts[lkey] = np.array(int_contacts[lkey], dtype=cvd.default_int)
+            int_contacts[lkey] = np.array(
+                int_contacts[lkey], dtype=cvd.default_int)
         contacts.append(int_contacts)
 
     # Add community contacts
-    c_contacts, _ = make_random_contacts(pop_size, {'c':community_contacts})
+    c_contacts, _ = contacts.make_random_contacts(
+        pop_size, {'c': community_contacts})
     for i in range(int(pop_size)):
-        contacts[i]['c'] = c_contacts[i]['c'] # Copy over community contacts -- present for everyone
+        # Copy over community contacts -- present for everyone
+        contacts[i]['c'] = c_contacts[i]['c']
 
     # Finalize
     popdict = {}
-    popdict['uid']        = np.array(list(uid_mapping.values()), dtype=cvd.default_int)
-    popdict['age']        = np.array(ages)
-    popdict['sex']        = np.array(sexes)
-    popdict['contacts']   = sc.dcp(contacts)
+    popdict['uid'] = np.array(
+        list(uid_mapping.values()), dtype=cvd.default_int)
+    popdict['age'] = np.array(ages)
+    popdict['sex'] = np.array(sexes)
+    popdict['contacts'] = sc.dcp(contacts)
     popdict['layer_keys'] = list(layer_mapping.values())
 
     return popdict

--- a/covasim/population.py
+++ b/covasim/population.py
@@ -21,7 +21,7 @@ __all__ = ['make_people', 'make_randpop', 'make_random_contacts',
            'make_synthpop']
 
 
-class population():
+class population(people):
     def make_people(self, sim, popdict=None, save_pop=False, popfile=None, die=True, reset=False, verbose=None, **kwargs):
         '''
         Make the actual people for the simulation. Usually called via sim.initialize(),

--- a/covasim/sim.py
+++ b/covasim/sim.py
@@ -2,7 +2,7 @@
 Defines the Sim class, Covasim's core class.
 '''
 
-#%% Imports
+# %% Imports
 import numpy as np
 import pandas as pd
 import sciris as sc
@@ -50,47 +50,50 @@ class Sim(cvb.BaseSim):
                  popfile=None, load_pop=False, save_pop=False, version=None, **kwargs):
 
         # Set attributes
-        self.label         = label    # The label/name of the simulation
-        self.created       = None     # The datetime the sim was created
-        self.simfile       = simfile  # The filename of the sim
-        self.datafile      = datafile # The name of the data file
-        self.popfile       = popfile  # The population file
-        self.load_pop      = load_pop # Whether to load the population
-        self.save_pop      = save_pop # Whether to save the population
-        self.data          = None     # The actual data
-        self.popdict       = None     # The population dictionary
-        self.t             = None     # The current time in the simulation (during execution); outside of sim.step(), its value corresponds to next timestep to be computed
-        self.people        = None     # Initialize these here so methods that check their length can see they're empty
-        self.results       = {}       # For storing results
-        self.summary       = None     # For storing a summary of the results
-        self.initialized   = False    # Whether or not initialization is complete
-        self.complete      = False    # Whether a simulation has completed running
+        self.label = label    # The label/name of the simulation
+        self.created = None     # The datetime the sim was created
+        self.simfile = simfile  # The filename of the sim
+        self.datafile = datafile  # The name of the data file
+        self.popfile = popfile  # The population file
+        self.load_pop = load_pop  # Whether to load the population
+        self.save_pop = save_pop  # Whether to save the population
+        self.data = None     # The actual data
+        self.popdict = None     # The population dictionary
+        # The current time in the simulation (during execution); outside of sim.step(), its value corresponds to next timestep to be computed
+        self.t = None
+        # Initialize these here so methods that check their length can see they're empty
+        self.people = None
+        self.results = {}       # For storing results
+        self.summary = None     # For storing a summary of the results
+        self.initialized = False    # Whether or not initialization is complete
+        self.complete = False    # Whether a simulation has completed running
         self.results_ready = False    # Whether or not results are ready
-        self._default_ver  = version  # Default version of parameters used
-        self._orig_pars    = None     # Store original parameters to optionally restore at the end of the simulation
+        self._default_ver = version  # Default version of parameters used
+        # Store original parameters to optionally restore at the end of the simulation
+        self._orig_pars = None
 
         # Make default parameters (using values from parameters.py)
-        default_pars = cvpar.make_pars(version=version) # Start with default pars
-        super().__init__(default_pars) # Initialize and set the parameters as attributes
+        default_pars = cvpar.make_pars(
+            version=version)  # Start with default pars
+        super().__init__(default_pars)  # Initialize and set the parameters as attributes
 
         # Now update everything
         self.set_metadata(simfile)  # Set the simulation date and filename
         self.update_pars(pars, **kwargs)   # Update the parameters, if provided
-        self.load_data(datafile, datacols) # Load the data, if provided
+        self.load_data(datafile, datacols)  # Load the data, if provided
 
         return
-
 
     def load_data(self, datafile=None, datacols=None, verbose=None, **kwargs):
         ''' Load the data to calibrate against, if provided '''
         if verbose is None:
             verbose = self['verbose']
-        self.datafile = datafile # Store this
-        if datafile is not None: # If a data file is provided, load it
-            self.data = cvm.load_data(datafile=datafile, columns=datacols, verbose=verbose, start_day=self['start_day'], **kwargs)
+        self.datafile = datafile  # Store this
+        if datafile is not None:  # If a data file is provided, load it
+            self.data = cvm.load_data(
+                datafile=datafile, columns=datacols, verbose=verbose, start_day=self['start_day'], **kwargs)
 
         return
-
 
     def initialize(self, reset=False, **kwargs):
         '''
@@ -104,21 +107,22 @@ class Sim(cvb.BaseSim):
             kwargs (dict): passed to init_people
         '''
         self.t = 0  # The current time index
-        self.validate_pars() # Ensure parameters have valid values
-        self.set_seed() # Reset the random seed before the population is created
-        self.init_variants() # Initialize the variants
-        self.init_immunity() # initialize information about immunity (if use_waning=True)
-        self.init_results() # After initializing the variant, create the results structure
-        self.init_people(save_pop=self.save_pop, load_pop=self.load_pop, popfile=self.popfile, reset=reset, **kwargs) # Create all the people (slow)
+        self.validate_pars()  # Ensure parameters have valid values
+        self.set_seed()  # Reset the random seed before the population is created
+        self.init_variants()  # Initialize the variants
+        self.init_immunity()  # initialize information about immunity (if use_waning=True)
+        self.init_results()  # After initializing the variant, create the results structure
+        self.init_people(save_pop=self.save_pop, load_pop=self.load_pop,
+                         popfile=self.popfile, reset=reset, **kwargs)  # Create all the people (slow)
         self.init_interventions()  # Initialize the interventions...
         self.init_analyzers()  # ...and the analyzers...
-        self.validate_layer_pars() # Once the population is initialized, validate the layer parameters again
-        self.set_seed() # Reset the random seed again so the random number stream is consistent
-        self.initialized   = True
-        self.complete      = False
+        # Once the population is initialized, validate the layer parameters again
+        self.validate_layer_pars()
+        self.set_seed()  # Reset the random seed again so the random number stream is consistent
+        self.initialized = True
+        self.complete = False
         self.results_ready = False
         return self
-
 
     def layer_keys(self):
         '''
@@ -129,11 +133,11 @@ class Sim(cvb.BaseSim):
         available).
         '''
         try:
-            keys = list(self['beta_layer'].keys()) # Get keys from beta_layer since the "most required" layer parameter
-        except: # pragma: no cover
+            # Get keys from beta_layer since the "most required" layer parameter
+            keys = list(self['beta_layer'].keys())
+        except:  # pragma: no cover
             keys = []
         return keys
-
 
     def reset_layer_pars(self, layer_keys=None, force=False):
         '''
@@ -144,13 +148,12 @@ class Sim(cvb.BaseSim):
             force (bool): reset the parameters even if they already exist
         '''
         if layer_keys is None:
-            if self.people is not None: # If people exist
+            if self.people is not None:  # If people exist
                 layer_keys = self.people.contacts.keys()
             elif self.popdict is not None:
                 layer_keys = self.popdict['layer_keys']
         cvpar.reset_layer_pars(self.pars, layer_keys=layer_keys, force=force)
         return
-
 
     def validate_layer_pars(self):
         '''
@@ -160,11 +163,12 @@ class Sim(cvb.BaseSim):
 
         # First, try to figure out what the layer keys should be and perform basic type checking
         layer_keys = self.layer_keys()
-        layer_pars = cvpar.layer_pars # The names of the parameters that are specified by layer
+        # The names of the parameters that are specified by layer
+        layer_pars = cvpar.layer_pars
         for lp in layer_pars:
             val = self[lp]
-            if sc.isnumber(val): # It's a scalar instead of a dict, assume it's all contacts
-                self[lp] = {k:val for k in layer_keys}
+            if sc.isnumber(val):  # It's a scalar instead of a dict, assume it's all contacts
+                self[lp] = {k: val for k in layer_keys}
 
         # Handle key mismatches
         for lp in layer_pars:
@@ -172,23 +176,23 @@ class Sim(cvb.BaseSim):
             if not lp_keys == set(layer_keys):
                 errormsg = 'At least one layer parameter is inconsistent with the layer keys; all parameters must have the same keys:'
                 errormsg += f'\nsim.layer_keys() = {layer_keys}'
-                for lp2 in layer_pars: # Fail on first error, but re-loop to list all of them
-                    errormsg += f'\n{lp2} = ' + ', '.join(self.pars[lp2].keys())
+                for lp2 in layer_pars:  # Fail on first error, but re-loop to list all of them
+                    errormsg += f'\n{lp2} = ' + \
+                        ', '.join(self.pars[lp2].keys())
                 raise sc.KeyNotFoundError(errormsg)
 
         # Handle mismatches with the population
         if self.people is not None:
             pop_keys = set(self.people.contacts.keys())
-            if pop_keys != set(layer_keys): # pragma: no cover
+            if pop_keys != set(layer_keys):  # pragma: no cover
                 if not len(pop_keys):
-                    errormsg = f'Your population does not have any layer keys, but your simulation does {layer_keys}. If you called cv.People() directly, you probably need cv.make_people() instead.'
+                    errormsg = f'Your population does not have any layer keys, but your simulation does {layer_keys}. If you called cv.People() directly, you probably need cv.population.make_people() instead.'
                     raise sc.KeyNotFoundError(errormsg)
                 else:
                     errormsg = f'Please update your parameter keys {layer_keys} to match population keys {pop_keys}. You may find sim.reset_layer_pars() helpful.'
                     raise sc.KeyNotFoundError(errormsg)
 
         return
-
 
     def validate_pars(self, validate_layers=True):
         '''
@@ -199,13 +203,13 @@ class Sim(cvb.BaseSim):
         '''
 
         # Handle population size
-        pop_size   = self.pars.get('pop_size')
+        pop_size = self.pars.get('pop_size')
         scaled_pop = self.pars.get('scaled_pop')
-        pop_scale  = self.pars.get('pop_scale')
-        if scaled_pop is not None: # If scaled_pop is supplied, try to use it
-            if pop_scale in [None, 1.0]: # Normal case, recalculate population scale
+        pop_scale = self.pars.get('pop_scale')
+        if scaled_pop is not None:  # If scaled_pop is supplied, try to use it
+            if pop_scale in [None, 1.0]:  # Normal case, recalculate population scale
                 self['pop_scale'] = scaled_pop/pop_size
-            else: # Special case, recalculate number of agents
+            else:  # Special case, recalculate number of agents
                 self['pop_size'] = int(scaled_pop/pop_scale)
 
         # Handle types
@@ -217,8 +221,8 @@ class Sim(cvb.BaseSim):
                 raise ValueError(errormsg) from E
 
         # Handle start day
-        start_day = self['start_day'] # Shorten
-        if start_day in [None, 0]: # Use default start day
+        start_day = self['start_day']  # Shorten
+        if start_day in [None, 0]:  # Use default start day
             start_day = '2020-03-01'
         self['start_day'] = sc.date(start_day)
 
@@ -236,7 +240,8 @@ class Sim(cvb.BaseSim):
         else:
             if n_days:
                 self['n_days'] = int(n_days)
-                self['end_day'] = self.date(n_days) # Convert from the number of days to the end day
+                # Convert from the number of days to the end day
+                self['end_day'] = self.date(n_days)
             else:
                 errormsg = f'You must supply one of n_days and end_day, not "{n_days}" and "{end_day}"'
                 raise ValueError(errormsg)
@@ -244,20 +249,22 @@ class Sim(cvb.BaseSim):
         # Handle population data
         popdata_choices = ['random', 'hybrid', 'clustered', 'synthpops']
         choice = self['pop_type']
-        if choice and choice not in popdata_choices: # pragma: no cover
+        if choice and choice not in popdata_choices:  # pragma: no cover
             choicestr = ', '.join(popdata_choices)
             errormsg = f'Population type "{choice}" not available; choices are: {choicestr}'
             raise ValueError(errormsg)
 
         # Handle interventions, analyzers, and variants
-        self['interventions'] = sc.promotetolist(self['interventions'], keepnone=False)
-        for i,interv in enumerate(self['interventions']):
-            if isinstance(interv, dict): # It's a dictionary representation of an intervention
+        self['interventions'] = sc.promotetolist(
+            self['interventions'], keepnone=False)
+        for i, interv in enumerate(self['interventions']):
+            if isinstance(interv, dict):  # It's a dictionary representation of an intervention
                 self['interventions'][i] = cvi.InterventionDict(**interv)
         self['analyzers'] = sc.promotetolist(self['analyzers'], keepnone=False)
         self['variants'] = sc.promotetolist(self['variants'], keepnone=False)
         for key in ['interventions', 'analyzers', 'variants']:
-            self[key] = sc.dcp(self[key]) # All of these have initialize functions that run into issues if they're reused
+            # All of these have initialize functions that run into issues if they're reused
+            self[key] = sc.dcp(self[key])
 
         # Optionally handle layer parameters
         if validate_layers:
@@ -266,12 +273,11 @@ class Sim(cvb.BaseSim):
         # Handle verbose
         if self['verbose'] == 'brief':
             self['verbose'] = -1
-        if not sc.isnumber(self['verbose']): # pragma: no cover
+        if not sc.isnumber(self['verbose']):  # pragma: no cover
             errormsg = f'Verbose argument should be either "brief", -1, or a float, not {type(self["verbose"])} "{self["verbose"]}"'
             raise ValueError(errormsg)
 
         return
-
 
     def init_results(self):
         '''
@@ -288,59 +294,78 @@ class Sim(cvb.BaseSim):
             output = cvb.Result(*args, **kwargs, npts=self.npts)
             return output
 
-        dcols = cvd.get_default_colors() # Get default colors
+        dcols = cvd.get_default_colors()  # Get default colors
 
         # Flows and cumulative flows
-        for key,label in cvd.result_flows.items():
-            self.results[f'cum_{key}'] = init_res(f'Cumulative {label}', color=dcols[key])  # Cumulative variables -- e.g. "Cumulative infections"
+        for key, label in cvd.result_flows.items():
+            # Cumulative variables -- e.g. "Cumulative infections"
+            self.results[f'cum_{key}'] = init_res(
+                f'Cumulative {label}', color=dcols[key])
 
-        for key,label in cvd.result_flows.items(): # Repeat to keep all the cumulative keys together
-            self.results[f'new_{key}'] = init_res(f'Number of new {label}', color=dcols[key]) # Flow variables -- e.g. "Number of new infections"
+        for key, label in cvd.result_flows.items():  # Repeat to keep all the cumulative keys together
+            # Flow variables -- e.g. "Number of new infections"
+            self.results[f'new_{key}'] = init_res(
+                f'Number of new {label}', color=dcols[key])
 
         # Stock variables
-        for key,label in cvd.result_stocks.items():
+        for key, label in cvd.result_stocks.items():
             self.results[f'n_{key}'] = init_res(label, color=dcols[key])
 
         # Other variables
-        self.results['n_alive']             = init_res('Number alive', scale=True)
-        self.results['n_naive']             = init_res('Number never infected', scale=True)
-        self.results['n_preinfectious']     = init_res('Number preinfectious', scale=True, color=dcols.exposed)
-        self.results['n_removed']           = init_res('Number removed', scale=True, color=dcols.recovered)
-        self.results['prevalence']          = init_res('Prevalence', scale=False)
-        self.results['incidence']           = init_res('Incidence', scale=False)
-        self.results['r_eff']               = init_res('Effective reproduction number', scale=False)
-        self.results['doubling_time']       = init_res('Doubling time', scale=False)
-        self.results['test_yield']          = init_res('Testing yield', scale=False)
-        self.results['rel_test_yield']      = init_res('Relative testing yield', scale=False)
-        self.results['frac_vaccinated']     = init_res('Proportion vaccinated', scale=False)
-        self.results['pop_nabs']            = init_res('Population nab levels', scale=False, color=dcols.pop_nabs)
-        self.results['pop_protection']      = init_res('Population immunity protection', scale=False, color=dcols.pop_protection)
-        self.results['pop_symp_protection'] = init_res('Population symptomatic protection', scale=False, color=dcols.pop_symp_protection)
+        self.results['n_alive'] = init_res('Number alive', scale=True)
+        self.results['n_naive'] = init_res('Number never infected', scale=True)
+        self.results['n_preinfectious'] = init_res(
+            'Number preinfectious', scale=True, color=dcols.exposed)
+        self.results['n_removed'] = init_res(
+            'Number removed', scale=True, color=dcols.recovered)
+        self.results['prevalence'] = init_res('Prevalence', scale=False)
+        self.results['incidence'] = init_res('Incidence', scale=False)
+        self.results['r_eff'] = init_res(
+            'Effective reproduction number', scale=False)
+        self.results['doubling_time'] = init_res('Doubling time', scale=False)
+        self.results['test_yield'] = init_res('Testing yield', scale=False)
+        self.results['rel_test_yield'] = init_res(
+            'Relative testing yield', scale=False)
+        self.results['frac_vaccinated'] = init_res(
+            'Proportion vaccinated', scale=False)
+        self.results['pop_nabs'] = init_res(
+            'Population nab levels', scale=False, color=dcols.pop_nabs)
+        self.results['pop_protection'] = init_res(
+            'Population immunity protection', scale=False, color=dcols.pop_protection)
+        self.results['pop_symp_protection'] = init_res(
+            'Population symptomatic protection', scale=False, color=dcols.pop_symp_protection)
 
         # Handle variants
         nv = self['n_variants']
         self.results['variant'] = {}
-        self.results['variant']['prevalence_by_variant'] = init_res('Prevalence by variant', scale=False, n_variants=nv)
-        self.results['variant']['incidence_by_variant']  = init_res('Incidence by variant', scale=False, n_variants=nv)
-        for key,label in cvd.result_flows_by_variant.items():
-            self.results['variant'][f'cum_{key}'] = init_res(f'Cumulative {label}', color=dcols[key], n_variants=nv)  # Cumulative variables -- e.g. "Cumulative infections"
-        for key,label in cvd.result_flows_by_variant.items():
-            self.results['variant'][f'new_{key}'] = init_res(f'Number of new {label}', color=dcols[key], n_variants=nv) # Flow variables -- e.g. "Number of new infections"
-        for key,label in cvd.result_stocks_by_variant.items():
-            self.results['variant'][f'n_{key}'] = init_res(label, color=dcols[key], n_variants=nv)
+        self.results['variant']['prevalence_by_variant'] = init_res(
+            'Prevalence by variant', scale=False, n_variants=nv)
+        self.results['variant']['incidence_by_variant'] = init_res(
+            'Incidence by variant', scale=False, n_variants=nv)
+        for key, label in cvd.result_flows_by_variant.items():
+            # Cumulative variables -- e.g. "Cumulative infections"
+            self.results['variant'][f'cum_{key}'] = init_res(
+                f'Cumulative {label}', color=dcols[key], n_variants=nv)
+        for key, label in cvd.result_flows_by_variant.items():
+            # Flow variables -- e.g. "Number of new infections"
+            self.results['variant'][f'new_{key}'] = init_res(
+                f'Number of new {label}', color=dcols[key], n_variants=nv)
+        for key, label in cvd.result_stocks_by_variant.items():
+            self.results['variant'][f'n_{key}'] = init_res(
+                label, color=dcols[key], n_variants=nv)
 
         # Populate the rest of the results
         if self['rescale']:
             scale = 1
         else:
             scale = self['pop_scale']
-        self.rescale_vec   = scale*np.ones(self.npts) # Not included in the results, but used to scale them
+        # Not included in the results, but used to scale them
+        self.rescale_vec = scale*np.ones(self.npts)
         self.results['date'] = self.datevec
-        self.results['t']    = self.tvec
-        self.results_ready   = False
+        self.results['t'] = self.tvec
+        self.results_ready = False
 
         return
-
 
     def load_population(self, popfile=None, **kwargs):
         '''
@@ -363,43 +388,43 @@ class Sim(cvb.BaseSim):
         if popfile is not None:
 
             # Load from disk or use directly
-            if isinstance(popfile, str): # It's a string, assume it's a filename
+            if isinstance(popfile, str):  # It's a string, assume it's a filename
                 filepath = sc.makefilepath(filename=popfile, **kwargs)
                 obj = cvm.load(filepath)
                 if self['verbose']:
                     print(f'Loading population from {filepath}')
             else:
-                obj = popfile # Use it directly
+                obj = popfile  # Use it directly
 
             # Process the input
             if isinstance(obj, dict):
                 self.popdict = obj
-                n_actual     = len(self.popdict['uid'])
-                layer_keys   = self.popdict['layer_keys']
+                n_actual = len(self.popdict['uid'])
+                layer_keys = self.popdict['layer_keys']
 
             elif isinstance(obj, cvb.BasePeople):
                 n_actual = len(obj)
                 self.people = obj
-                self.people.set_pars(self.pars) # Replace the saved parameters with this simulation's
-                layer_keys  = self.people.layer_keys()
+                # Replace the saved parameters with this simulation's
+                self.people.set_pars(self.pars)
+                layer_keys = self.people.layer_keys()
 
                 # Perform validation
                 n_expected = self['pop_size']
-                if n_actual != n_expected: # External consistency check
+                if n_actual != n_expected:  # External consistency check
                     errormsg = f'Wrong number of people ({n_expected:n} requested, {n_actual:n} actual) -- please change "pop_size" to match or regenerate the file'
                     raise ValueError(errormsg)
-                self.people.validate() # Internal consistency check
+                self.people.validate()  # Internal consistency check
 
-            else: # pragma: no cover
+            else:  # pragma: no cover
                 errormsg = f'Cound not interpret input of {type(obj)} as a population file: must be a dict or People object'
                 raise ValueError(errormsg)
 
-
-            self.reset_layer_pars(force=False, layer_keys=layer_keys) # Ensure that layer keys match the loaded population
-            self.popfile = None # Once loaded, remove to save memory
+            # Ensure that layer keys match the loaded population
+            self.reset_layer_pars(force=False, layer_keys=layer_keys)
+            self.popfile = None  # Once loaded, remove to save memory
 
         return
-
 
     def init_people(self, save_pop=False, load_pop=False, popfile=None, reset=False, verbose=None, **kwargs):
         '''
@@ -411,27 +436,31 @@ class Sim(cvb.BaseSim):
             popfile   (str): filename to load/save the population
             reset    (bool): whether to regenerate the people even if they already exist
             verbose   (int): detail to print
-            kwargs   (dict): passed to cv.make_people()
+            kwargs   (dict): passed to cv.population.make_people()
         '''
 
         # Handle inputs
         if verbose is None:
             verbose = self['verbose']
         if verbose > 0:
-            resetstr= ''
+            resetstr = ''
             if self.people:
                 resetstr = ' (resetting people)' if reset else ' (warning: not resetting sim.people)'
-            print(f'Initializing sim{resetstr} with {self["pop_size"]:0n} people for {self["n_days"]} days')
-        if load_pop and self.popdict is None: # If there's a popdict, we initialize it via cvpop.make_people()
+            print(
+                f'Initializing sim{resetstr} with {self["pop_size"]:0n} people for {self["n_days"]} days')
+        # If there's a popdict, we initialize it via cvpop.population.make_people()
+        if load_pop and self.popdict is None:
             self.load_population(popfile=popfile)
 
         # Actually make the people
-        self.people = cvpop.make_people(self, save_pop=save_pop, popfile=popfile, reset=reset, verbose=verbose, **kwargs)
-        self.people.initialize() # Fully initialize the people
+        self.people = cvpop.population.make_people(
+            self, save_pop=save_pop, popfile=popfile, reset=reset, verbose=verbose, **kwargs)
+        self.people.initialize()  # Fully initialize the people
 
         # Handle anyone who isn't susceptible
         if self['frac_susceptible'] < 1:
-            inds = cvu.choose(self['pop_size'], np.round((1-self['frac_susceptible'])*self['pop_size']))
+            inds = cvu.choose(self['pop_size'], np.round(
+                (1-self['frac_susceptible'])*self['pop_size']))
             self.people.make_nonnaive(inds=inds)
 
         # Create the seed infections
@@ -441,28 +470,30 @@ class Sim(cvb.BaseSim):
 
         return
 
-
     def init_interventions(self):
         ''' Initialize and validate the interventions '''
 
         # Initialization
         if self._orig_pars and 'interventions' in self._orig_pars:
-            self['interventions'] = self._orig_pars.pop('interventions') # Restore
+            self['interventions'] = self._orig_pars.pop(
+                'interventions')  # Restore
 
-        for i,intervention in enumerate(self['interventions']):
+        for i, intervention in enumerate(self['interventions']):
             if isinstance(intervention, cvi.Intervention):
                 intervention.initialize(self)
 
         # Validation
-        trace_ind = np.nan # Index of the tracing intervention(s)
-        test_ind = np.nan # Index of the tracing intervention(s)
-        for i,intervention in enumerate(self['interventions']):
+        trace_ind = np.nan  # Index of the tracing intervention(s)
+        test_ind = np.nan  # Index of the tracing intervention(s)
+        for i, intervention in enumerate(self['interventions']):
             if isinstance(intervention, (cvi.contact_tracing)):
-                trace_ind = np.fmin(trace_ind, i) # Find the earliest-scheduled tracing intervention
+                # Find the earliest-scheduled tracing intervention
+                trace_ind = np.fmin(trace_ind, i)
             elif isinstance(intervention, (cvi.test_num, cvi.test_prob)):
-                test_ind = np.fmax(test_ind, i) # Find the latest-scheduled testing intervention
+                # Find the latest-scheduled testing intervention
+                test_ind = np.fmax(test_ind, i)
 
-        if not np.isnan(trace_ind): # pragma: no cover
+        if not np.isnan(trace_ind):  # pragma: no cover
             warningmsg = ''
             if np.isnan(test_ind):
                 warningmsg = 'Note: you have defined a contact tracing intervention but no testing intervention was found. Unless this is intentional, please define at least one testing intervention.'
@@ -473,50 +504,46 @@ class Sim(cvb.BaseSim):
 
         return
 
-
     def finalize_interventions(self):
         for intervention in self['interventions']:
             if isinstance(intervention, cvi.Intervention):
                 intervention.finalize(self)
 
-
     def init_analyzers(self):
         ''' Initialize the analyzers '''
         if self._orig_pars and 'analyzers' in self._orig_pars:
-            self['analyzers'] = self._orig_pars.pop('analyzers') # Restore
+            self['analyzers'] = self._orig_pars.pop('analyzers')  # Restore
 
         for analyzer in self['analyzers']:
             if isinstance(analyzer, cva.Analyzer):
                 analyzer.initialize(self)
         return
 
-
     def finalize_analyzers(self):
         for analyzer in self['analyzers']:
             if isinstance(analyzer, cva.Analyzer):
                 analyzer.finalize(self)
 
-
     def init_variants(self):
         ''' Initialize the variants '''
         if self._orig_pars and 'variants' in self._orig_pars:
-            self['variants'] = self._orig_pars.pop('variants') # Restore
+            self['variants'] = self._orig_pars.pop('variants')  # Restore
 
-        for i,variant in enumerate(self['variants']):
+        for i, variant in enumerate(self['variants']):
             if isinstance(variant, cvimm.variant):
                 if not variant.initialized:
                     variant.initialize(self)
-            else: # pragma: no cover
+            else:  # pragma: no cover
                 errormsg = f'Variant {i} ({variant}) is not a cv.variant object; please create using cv.variant()'
                 raise TypeError(errormsg)
 
         len_pars = len(self['variant_pars'])
         len_map = len(self['variant_map'])
         assert len_pars == len_map, f"variant_pars and variant_map must be the same length, but they're not: {len_pars} ≠ {len_map}"
-        self['n_variants'] = len_pars # Each variant has an entry in variant_pars
+        # Each variant has an entry in variant_pars
+        self['n_variants'] = len_pars
 
         return
-
 
     def init_immunity(self, create=False):
         ''' Initialize immunity matrices and precompute nab waning for each variant '''
@@ -524,29 +551,39 @@ class Sim(cvb.BaseSim):
             cvimm.init_immunity(self, create=create)
         return
 
-
     def rescale(self):
         ''' Dynamically rescale the population -- used during step() '''
         if self['rescale']:
             pop_scale = self['pop_scale']
             current_scale = self.rescale_vec[self.t]
-            if current_scale < pop_scale: # We have room to rescale
-                not_naive_inds = self.people.false('naive') # Find everyone not naive
-                n_not_naive = len(not_naive_inds) # Number of people who are not naive
-                n_people = self['pop_size'] # Number of people overall
-                current_ratio = n_not_naive/n_people # Current proportion not naive
-                threshold = self['rescale_threshold'] # Threshold to trigger rescaling
-                if current_ratio > threshold: # Check if we've reached point when we want to rescale
-                    max_ratio = pop_scale/current_scale # We don't want to exceed the total population size
-                    proposed_ratio = max(current_ratio/threshold, self['rescale_factor']) # The proposed ratio to rescale: the rescale factor, unless we've exceeded it
-                    scaling_ratio = min(proposed_ratio, max_ratio) # We don't want to scale by more than the maximum ratio
-                    self.rescale_vec[self.t:] *= scaling_ratio # Update the rescaling factor from here on
-                    n = int(round(n_not_naive*(1.0-1.0/scaling_ratio))) # For example, rescaling by 2 gives n = 0.5*not_naive_inds
-                    choices = cvu.choose(max_n=n_not_naive, n=n) # Choose who to make naive again
-                    new_naive_inds = not_naive_inds[choices] # Convert these back into indices for people
-                    self.people.make_naive(new_naive_inds) # Make people naive again
+            if current_scale < pop_scale:  # We have room to rescale
+                not_naive_inds = self.people.false(
+                    'naive')  # Find everyone not naive
+                # Number of people who are not naive
+                n_not_naive = len(not_naive_inds)
+                n_people = self['pop_size']  # Number of people overall
+                current_ratio = n_not_naive/n_people  # Current proportion not naive
+                # Threshold to trigger rescaling
+                threshold = self['rescale_threshold']
+                if current_ratio > threshold:  # Check if we've reached point when we want to rescale
+                    # We don't want to exceed the total population size
+                    max_ratio = pop_scale/current_scale
+                    # The proposed ratio to rescale: the rescale factor, unless we've exceeded it
+                    proposed_ratio = max(
+                        current_ratio/threshold, self['rescale_factor'])
+                    # We don't want to scale by more than the maximum ratio
+                    scaling_ratio = min(proposed_ratio, max_ratio)
+                    # Update the rescaling factor from here on
+                    self.rescale_vec[self.t:] *= scaling_ratio
+                    # For example, rescaling by 2 gives n = 0.5*not_naive_inds
+                    n = int(round(n_not_naive*(1.0-1.0/scaling_ratio)))
+                    # Choose who to make naive again
+                    choices = cvu.choose(max_n=n_not_naive, n=n)
+                    # Convert these back into indices for people
+                    new_naive_inds = not_naive_inds[choices]
+                    # Make people naive again
+                    self.people.make_naive(new_naive_inds)
         return
-
 
     def step(self):
         '''
@@ -556,24 +593,33 @@ class Sim(cvb.BaseSim):
 
         # Set the time and if we have reached the end of the simulation, then do nothing
         if self.complete:
-            raise AlreadyRunError('Simulation already complete (call sim.initialize() to re-run)')
+            raise AlreadyRunError(
+                'Simulation already complete (call sim.initialize() to re-run)')
 
         t = self.t
 
         # Perform initial operations
-        self.rescale() # Check if we need to rescale
-        people   = self.people # Shorten this for later use
-        people.update_states_pre(t=t) # Update the state of everyone and count the flows
-        contacts = people.update_contacts() # Compute new contacts
-        hosp_max = people.count('severe')   > self['n_beds_hosp'] if self['n_beds_hosp'] is not None else False # Check for acute bed constraint
-        icu_max  = people.count('critical') > self['n_beds_icu']  if self['n_beds_icu']  is not None else False # Check for ICU bed constraint
+        self.rescale()  # Check if we need to rescale
+        people = self.people  # Shorten this for later use
+        # Update the state of everyone and count the flows
+        people.update_states_pre(t=t)
+        contacts = people.update_contacts()  # Compute new contacts
+        # Check for acute bed constraint
+        hosp_max = people.count(
+            'severe') > self['n_beds_hosp'] if self['n_beds_hosp'] is not None else False
+        # Check for ICU bed constraint
+        icu_max = people.count(
+            'critical') > self['n_beds_icu'] if self['n_beds_icu'] is not None else False
 
         # Randomly infect some people (imported infections)
         if self['n_imports']:
-            n_imports = cvu.poisson(self['n_imports']/self.rescale_vec[self.t]) # Imported cases
-            if n_imports>0:
-                importation_inds = cvu.choose(max_n=self['pop_size'], n=n_imports)
-                people.infect(inds=importation_inds, hosp_max=hosp_max, icu_max=icu_max, layer='importation')
+            n_imports = cvu.poisson(
+                self['n_imports']/self.rescale_vec[self.t])  # Imported cases
+            if n_imports > 0:
+                importation_inds = cvu.choose(
+                    max_n=self['pop_size'], n=n_imports)
+                people.infect(inds=importation_inds, hosp_max=hosp_max,
+                              icu_max=icu_max, layer='importation')
 
         # Add variants
         for variant in self['variants']:
@@ -581,10 +627,10 @@ class Sim(cvb.BaseSim):
                 variant.apply(self)
 
         # Apply interventions
-        for i,intervention in enumerate(self['interventions']):
-            intervention(self) # If it's a function, call it directly
+        for i, intervention in enumerate(self['interventions']):
+            intervention(self)  # If it's a function, call it directly
 
-        people.update_states_post() # Check for state changes after interventions
+        people.update_states_post()  # Check for state changes after interventions
 
         # Compute viral loads
         frac_time = cvd.default_float(self['viral_dist']['frac_time'])
@@ -593,10 +639,11 @@ class Sim(cvb.BaseSim):
         date_inf = people.date_infectious
         date_rec = people.date_recovered
         date_dead = people.date_dead
-        viral_load = cvu.compute_viral_load(t, date_inf, date_rec, date_dead, frac_time, load_ratio, high_cap)
+        viral_load = cvu.compute_viral_load(
+            t, date_inf, date_rec, date_dead, frac_time, load_ratio, high_cap)
 
         # Shorten useful parameters
-        nv = self['n_variants'] # Shorten number of variants
+        nv = self['n_variants']  # Shorten number of variants
         sus = people.susceptible
         symp = people.symptomatic
         diag = people.diagnosed
@@ -631,40 +678,48 @@ class Sim(cvb.BaseSim):
                 betas = layer['beta']
 
                 # Compute relative transmission and susceptibility
-                inf_variant = people.infectious * (people.infectious_variant == variant) # TODO: move out of loop?
-                sus_imm = people.sus_imm[variant,:]
-                iso_factor  = cvd.default_float(self['iso_factor'][lkey])
+                inf_variant = people.infectious * \
+                    (people.infectious_variant ==
+                     variant)  # TODO: move out of loop?
+                sus_imm = people.sus_imm[variant, :]
+                iso_factor = cvd.default_float(self['iso_factor'][lkey])
                 quar_factor = cvd.default_float(self['quar_factor'][lkey])
-                beta_layer  = cvd.default_float(self['beta_layer'][lkey])
-                rel_trans, rel_sus = cvu.compute_trans_sus(prel_trans, prel_sus, inf_variant, sus, beta_layer, viral_load, symp, diag, quar, asymp_factor, iso_factor, quar_factor, sus_imm)
+                beta_layer = cvd.default_float(self['beta_layer'][lkey])
+                rel_trans, rel_sus = cvu.compute_trans_sus(
+                    prel_trans, prel_sus, inf_variant, sus, beta_layer, viral_load, symp, diag, quar, asymp_factor, iso_factor, quar_factor, sus_imm)
 
                 # Calculate actual transmission
-                for sources, targets in [[p1, p2], [p2, p1]]:  # Loop over the contact network from p1->p2 and p2->p1
-                    source_inds, target_inds = cvu.compute_infections(beta, sources, targets, betas, rel_trans, rel_sus)  # Calculate transmission!
-                    people.infect(inds=target_inds, hosp_max=hosp_max, icu_max=icu_max, source=source_inds, layer=lkey, variant=variant)  # Actually infect people
+                # Loop over the contact network from p1->p2 and p2->p1
+                for sources, targets in [[p1, p2], [p2, p1]]:
+                    source_inds, target_inds = cvu.compute_infections(
+                        beta, sources, targets, betas, rel_trans, rel_sus)  # Calculate transmission!
+                    people.infect(inds=target_inds, hosp_max=hosp_max, icu_max=icu_max,
+                                  source=source_inds, layer=lkey, variant=variant)  # Actually infect people
 
         # Update counts for this time step: stocks
         for key in cvd.result_stocks.keys():
             self.results[f'n_{key}'][t] = people.count(key)
         for key in cvd.result_stocks_by_variant.keys():
             for variant in range(nv):
-                self.results['variant'][f'n_{key}'][variant, t] = people.count_by_variant(key, variant)
+                self.results['variant'][f'n_{key}'][variant, t] = people.count_by_variant(
+                    key, variant)
 
         # Update counts for this time step: flows
-        for key,count in people.flows.items():
+        for key, count in people.flows.items():
             self.results[key][t] += count
-        for key,count in people.flows_variant.items():
+        for key, count in people.flows_variant.items():
             for variant in range(nv):
                 self.results['variant'][key][variant][t] += count[variant]
 
         # Update nab and immunity for this time step
         inds_alive = cvu.false(people.dead)
-        self.results['pop_nabs'][t]            = np.sum(people.nab[inds_alive[cvu.true(people.nab[inds_alive])]])/len(inds_alive)
-        self.results['pop_protection'][t]      = np.nanmean(people.sus_imm)
+        self.results['pop_nabs'][t] = np.sum(
+            people.nab[inds_alive[cvu.true(people.nab[inds_alive])]])/len(inds_alive)
+        self.results['pop_protection'][t] = np.nanmean(people.sus_imm)
         self.results['pop_symp_protection'][t] = np.nanmean(people.symp_imm)
 
         # Apply analyzers -- same syntax as interventions
-        for i,analyzer in enumerate(self['analyzers']):
+        for i, analyzer in enumerate(self['analyzers']):
             analyzer(self)
 
         # Tidy up
@@ -673,7 +728,6 @@ class Sim(cvb.BaseSim):
             self.complete = True
 
         return
-
 
     def run(self, do_plot=False, until=None, restore_pars=True, reset_seed=True, verbose=None):
         '''
@@ -695,7 +749,8 @@ class Sim(cvb.BaseSim):
 
         if not self.initialized:
             self.initialize()
-            self._orig_pars = sc.dcp(self.pars) # Create a copy of the parameters, to restore after the run, in case they are dynamically modified
+            # Create a copy of the parameters, to restore after the run, in case they are dynamically modified
+            self._orig_pars = sc.dcp(self.pars)
 
         if verbose is None:
             verbose = self['verbose']
@@ -707,13 +762,16 @@ class Sim(cvb.BaseSim):
 
         until = self.npts if until is None else self.day(until)
         if until > self.npts:
-            raise AlreadyRunError(f'Requested to run until t={until} but the simulation end is t={self.npts}')
+            raise AlreadyRunError(
+                f'Requested to run until t={until} but the simulation end is t={self.npts}')
 
         if self.complete:
-            raise AlreadyRunError('Simulation is already complete (call sim.initialize() to re-run)')
+            raise AlreadyRunError(
+                'Simulation is already complete (call sim.initialize() to re-run)')
 
-        if self.t >= until: # NB. At the start, self.t is None so this check must occur after initialization
-            raise AlreadyRunError(f'Simulation is currently at t={self.t}, requested to run until t={until} which has already been reached')
+        if self.t >= until:  # NB. At the start, self.t is None so this check must occur after initialization
+            raise AlreadyRunError(
+                f'Simulation is currently at t={self.t}, requested to run until t={until} which has already been reached')
 
         # Main simulation loop
         while self.t < until:
@@ -721,10 +779,12 @@ class Sim(cvb.BaseSim):
             # Check if we were asked to stop
             elapsed = sc.toc(T, output=True)
             if self['timelimit'] and elapsed > self['timelimit']:
-                sc.printv(f"Time limit ({self['timelimit']} s) exceeded; call sim.finalize() to compute results if desired", 1, verbose)
+                sc.printv(
+                    f"Time limit ({self['timelimit']} s) exceeded; call sim.finalize() to compute results if desired", 1, verbose)
                 return
             elif self['stopping_func'] and self['stopping_func'](self):
-                sc.printv("Stopping function terminated the simulation; call sim.finalize() to compute results if desired", 1, verbose)
+                sc.printv(
+                    "Stopping function terminated the simulation; call sim.finalize() to compute results if desired", 1, verbose)
                 return
 
             # Print progress
@@ -733,9 +793,10 @@ class Sim(cvb.BaseSim):
                 string = f'  Running {simlabel}{self.datevec[self.t]} ({self.t:2.0f}/{self.pars["n_days"]}) ({elapsed:0.2f} s) '
                 if verbose >= 2:
                     sc.heading(string)
-                elif verbose>0:
+                elif verbose > 0:
                     if not (self.t % int(1.0/verbose)):
-                        sc.progressbar(self.t+1, self.npts, label=string, length=20, newline=True)
+                        sc.progressbar(self.t+1, self.npts,
+                                       label=string, length=20, newline=True)
 
             # Do the heavy lifting -- actually run the model!
             self.step()
@@ -745,7 +806,6 @@ class Sim(cvb.BaseSim):
             self.finalize(verbose=verbose, restore_pars=restore_pars)
             sc.printv(f'Run finished after {elapsed:0.2f} s.\n', 1, verbose)
         return self
-
 
     def finalize(self, verbose=None, restore_pars=True):
         ''' Compute final results '''
@@ -757,19 +817,23 @@ class Sim(cvb.BaseSim):
 
         # Scale the results
         for reskey in self.result_keys():
-            if self.results[reskey].scale: # Scale the result dynamically
+            if self.results[reskey].scale:  # Scale the result dynamically
                 self.results[reskey].values *= self.rescale_vec
         for reskey in self.result_keys('variant'):
-            if self.results['variant'][reskey].scale: # Scale the result dynamically
-                self.results['variant'][reskey].values = np.einsum('ij,j->ij', self.results['variant'][reskey].values, self.rescale_vec)
+            if self.results['variant'][reskey].scale:  # Scale the result dynamically
+                self.results['variant'][reskey].values = np.einsum(
+                    'ij,j->ij', self.results['variant'][reskey].values, self.rescale_vec)
 
         # Calculate cumulative results
         for key in cvd.result_flows.keys():
-            self.results[f'cum_{key}'][:] = np.cumsum(self.results[f'new_{key}'][:], axis=0)
+            self.results[f'cum_{key}'][:] = np.cumsum(
+                self.results[f'new_{key}'][:], axis=0)
         for key in cvd.result_flows_by_variant.keys():
             for variant in range(self['n_variants']):
-                self.results['variant'][f'cum_{key}'][variant, :] = np.cumsum(self.results['variant'][f'new_{key}'][variant, :], axis=0)
-        for res in [self.results['cum_infections'], self.results['variant']['cum_infections_by_variant']]: # Include initially infected people
+                self.results['variant'][f'cum_{key}'][variant, :] = np.cumsum(
+                    self.results['variant'][f'new_{key}'][variant, :], axis=0)
+        # Include initially infected people
+        for res in [self.results['cum_infections'], self.results['variant']['cum_infections_by_variant']]:
             res.values += self['pop_infected']*self.rescale_vec[0]
 
         # Finalize interventions and analyzers
@@ -777,29 +841,32 @@ class Sim(cvb.BaseSim):
         self.finalize_analyzers()
 
         # Final settings
-        self.results_ready = True # Set this first so self.summary() knows to print the results
-        self.t -= 1 # During the run, this keeps track of the next step; restore this be the final day of the sim
+        self.results_ready = True  # Set this first so self.summary() knows to print the results
+        self.t -= 1  # During the run, this keeps track of the next step; restore this be the final day of the sim
 
         # Perform calculations on results
-        self.compute_results(verbose=verbose) # Calculate the rest of the results
-        self.results = sc.objdict(self.results) # Convert results to a odicts/objdict to allow e.g. sim.results.diagnoses
+        # Calculate the rest of the results
+        self.compute_results(verbose=verbose)
+        # Convert results to a odicts/objdict to allow e.g. sim.results.diagnoses
+        self.results = sc.objdict(self.results)
 
         if restore_pars and self._orig_pars:
             preserved = ['analyzers', 'interventions']
-            orig_pars_keys = list(self._orig_pars.keys()) # Get a list of keys so we can iterate over them
+            # Get a list of keys so we can iterate over them
+            orig_pars_keys = list(self._orig_pars.keys())
             for key in orig_pars_keys:
                 if key not in preserved:
-                    self.pars[key] = self._orig_pars.pop(key) # Restore everything except for the analyzers and interventions
+                    # Restore everything except for the analyzers and interventions
+                    self.pars[key] = self._orig_pars.pop(key)
 
         # Optionally print summary output
-        if verbose: # Verbose is any non-zero value
-            if verbose>0: # Verbose is any positive number
-                self.summarize() # Print medium-length summary of the sim
+        if verbose:  # Verbose is any non-zero value
+            if verbose > 0:  # Verbose is any positive number
+                self.summarize()  # Print medium-length summary of the sim
             else:
-                self.brief() # Print brief summary of the sim
+                self.brief()  # Print brief summary of the sim
 
         return
-
 
     def compute_results(self, verbose=None):
         ''' Perform final calculations on the results '''
@@ -810,7 +877,6 @@ class Sim(cvb.BaseSim):
         self.compute_summary()
         return
 
-
     def compute_states(self):
         '''
         Compute prevalence, incidence, and other states. Prevalence is the current
@@ -820,21 +886,32 @@ class Sim(cvb.BaseSim):
         the number removed, and recalculates susceptibles to handle scaling.
         '''
         res = self.results
-        count_recov = 1-self['use_waning'] # If waning is on, don't count recovered people as removed
-        self.results['n_alive'][:]         = self.scaled_pop_size - res['cum_deaths'][:] # Number of people still alive
-        self.results['n_naive'][:]         = self.scaled_pop_size - res['cum_deaths'][:] - res['n_recovered'][:] - res['n_exposed'][:] # Number of people naive
-        self.results['n_susceptible'][:]   = res['n_alive'][:] - res['n_exposed'][:] - count_recov*res['cum_recoveries'][:] # Recalculate the number of susceptible people, not agents
-        self.results['n_preinfectious'][:] = res['n_exposed'][:] - res['n_infectious'][:] # Calculate the number not yet infectious: exposed minus infectious
-        self.results['n_removed'][:]       = count_recov*res['cum_recoveries'][:] + res['cum_deaths'][:] # Calculate the number removed: recovered + dead
-        self.results['prevalence'][:]      = res['n_exposed'][:]/res['n_alive'][:] # Calculate the prevalence
-        self.results['incidence'][:]       = res['new_infections'][:]/res['n_susceptible'][:] # Calculate the incidence
-        self.results['frac_vaccinated'][:] = res['n_vaccinated'][:]/res['n_alive'][:] # Calculate the fraction vaccinated
+        # If waning is on, don't count recovered people as removed
+        count_recov = 1-self['use_waning']
+        self.results['n_alive'][:] = self.scaled_pop_size - \
+            res['cum_deaths'][:]  # Number of people still alive
+        self.results['n_naive'][:] = self.scaled_pop_size - res['cum_deaths'][:] - \
+            res['n_recovered'][:] - res['n_exposed'][:]  # Number of people naive
+        self.results['n_susceptible'][:] = res['n_alive'][:] - res['n_exposed'][:] - count_recov * \
+            res['cum_recoveries'][:]  # Recalculate the number of susceptible people, not agents
+        # Calculate the number not yet infectious: exposed minus infectious
+        self.results['n_preinfectious'][:] = res['n_exposed'][:] - \
+            res['n_infectious'][:]
+        self.results['n_removed'][:] = count_recov*res['cum_recoveries'][:] + \
+            res['cum_deaths'][:]  # Calculate the number removed: recovered + dead
+        self.results['prevalence'][:] = res['n_exposed'][:] / \
+            res['n_alive'][:]  # Calculate the prevalence
+        self.results['incidence'][:] = res['new_infections'][:] / \
+            res['n_susceptible'][:]  # Calculate the incidence
+        self.results['frac_vaccinated'][:] = res['n_vaccinated'][:] / \
+            res['n_alive'][:]  # Calculate the fraction vaccinated
 
-        self.results['variant']['incidence_by_variant'][:] = np.einsum('ji,i->ji',res['variant']['new_infections_by_variant'][:], 1/res['n_susceptible'][:]) # Calculate the incidence
-        self.results['variant']['prevalence_by_variant'][:] = np.einsum('ji,i->ji',res['variant']['new_infections_by_variant'][:], 1/res['n_alive'][:])  # Calculate the prevalence
+        self.results['variant']['incidence_by_variant'][:] = np.einsum(
+            'ji,i->ji', res['variant']['new_infections_by_variant'][:], 1/res['n_susceptible'][:])  # Calculate the incidence
+        self.results['variant']['prevalence_by_variant'][:] = np.einsum(
+            'ji,i->ji', res['variant']['new_infections_by_variant'][:], 1/res['n_alive'][:])  # Calculate the prevalence
 
         return
-
 
     def compute_yield(self):
         '''
@@ -845,15 +922,20 @@ class Sim(cvb.BaseSim):
         '''
         # Absolute yield
         res = self.results
-        inds = cvu.true(res['new_tests'][:]) # Pull out non-zero numbers of tests
-        self.results['test_yield'][inds] = res['new_diagnoses'][inds]/res['new_tests'][inds] # Calculate the yield
+        # Pull out non-zero numbers of tests
+        inds = cvu.true(res['new_tests'][:])
+        self.results['test_yield'][inds] = res['new_diagnoses'][inds] / \
+            res['new_tests'][inds]  # Calculate the yield
 
         # Relative yield
-        inds = cvu.true(res['n_infectious'][:]) # To avoid divide by zero if no one is infectious
-        denom = res['n_infectious'][inds] / (res['n_alive'][inds] - res['cum_diagnoses'][inds]) # Alive + undiagnosed people might test; infectious people will test positive
-        self.results['rel_test_yield'][inds] = self.results['test_yield'][inds]/denom # Calculate the relative yield
+        # To avoid divide by zero if no one is infectious
+        inds = cvu.true(res['n_infectious'][:])
+        # Alive + undiagnosed people might test; infectious people will test positive
+        denom = res['n_infectious'][inds] / \
+            (res['n_alive'][inds] - res['cum_diagnoses'][inds])
+        # Calculate the relative yield
+        self.results['rel_test_yield'][inds] = self.results['test_yield'][inds]/denom
         return
-
 
     def compute_doubling(self, window=3, max_doubling_time=30):
         '''
@@ -875,11 +957,12 @@ class Sim(cvb.BaseSim):
         infections_now = cum_infections[window:]
         infections_prev = cum_infections[:-window]
         use = (infections_prev > 0) & (infections_now > infections_prev)
-        doubling_time = window * np.log(2) / np.log(infections_now[use] / infections_prev[use])
+        doubling_time = window * \
+            np.log(2) / np.log(infections_now[use] / infections_prev[use])
         self.results['doubling_time'][:] = np.nan
-        self.results['doubling_time'][window:][use] = np.minimum(doubling_time, max_doubling_time)
+        self.results['doubling_time'][window:][use] = np.minimum(
+            doubling_time, max_doubling_time)
         return self.results['doubling_time'].values
-
 
     def compute_r_eff(self, method='daily', smoothing=2, window=7):
         '''
@@ -903,27 +986,37 @@ class Sim(cvb.BaseSim):
         if method == 'daily':
 
             # Find the dates that everyone became infectious and recovered, and hence calculate infectious duration
-            recov_inds   = self.people.defined('date_recovered')
-            dead_inds    = self.people.defined('date_dead')
-            date_recov   = self.people.date_recovered[recov_inds]
-            date_dead    = self.people.date_dead[dead_inds]
+            recov_inds = self.people.defined('date_recovered')
+            dead_inds = self.people.defined('date_dead')
+            date_recov = self.people.date_recovered[recov_inds]
+            date_dead = self.people.date_dead[dead_inds]
             date_outcome = np.concatenate((date_recov, date_dead))
-            inds         = np.concatenate((recov_inds, dead_inds))
-            date_inf     = self.people.date_infectious[inds]
-            mean_inf     = date_outcome.mean() - date_inf.mean()
+            inds = np.concatenate((recov_inds, dead_inds))
+            date_inf = self.people.date_infectious[inds]
+            mean_inf = date_outcome.mean() - date_inf.mean()
 
             # Calculate R_eff as the mean infectious duration times the number of new infectious divided by the number of infectious people on a given day
-            raw_values = mean_inf*self.results['new_infections'].values/(self.results['n_infectious'].values+1e-6)
-            len_raw = len(raw_values) # Calculate the number of raw values
-            if sc.checktype(self['dur'], list): dur_pars = self['dur'][0] # TODO: fix this, need to somehow take all variants into account
-            else: dur_pars = self['dur']
-            if len_raw >= 3: # Can't smooth arrays shorter than this since the default smoothing kernel has length 3
-                initial_period = dur_pars['exp2inf']['par1'] + dur_pars['asym2rec']['par1'] # Approximate the duration of the seed infections for averaging
-                initial_period = int(min(len_raw, initial_period)) # Ensure we don't have too many points
-                for ind in range(initial_period): # Loop over each of the initial inds
-                    raw_values[ind] = raw_values[ind:initial_period].mean() # Replace these values with their average
+            raw_values = mean_inf * \
+                self.results['new_infections'].values / \
+                (self.results['n_infectious'].values+1e-6)
+            len_raw = len(raw_values)  # Calculate the number of raw values
+            if sc.checktype(self['dur'], list):
+                # TODO: fix this, need to somehow take all variants into account
+                dur_pars = self['dur'][0]
+            else:
+                dur_pars = self['dur']
+            if len_raw >= 3:  # Can't smooth arrays shorter than this since the default smoothing kernel has length 3
+                # Approximate the duration of the seed infections for averaging
+                initial_period = dur_pars['exp2inf']['par1'] + \
+                    dur_pars['asym2rec']['par1']
+                # Ensure we don't have too many points
+                initial_period = int(min(len_raw, initial_period))
+                for ind in range(initial_period):  # Loop over each of the initial inds
+                    # Replace these values with their average
+                    raw_values[ind] = raw_values[ind:initial_period].mean()
                 values = sc.smooth(raw_values, smoothing)
-                values[:smoothing] = raw_values[:smoothing] # To avoid numerical effects, replace the beginning and end with the original
+                # To avoid numerical effects, replace the beginning and end with the original
+                values[:smoothing] = raw_values[:smoothing]
                 values[-smoothing:] = raw_values[-smoothing:]
             else:
                 values = raw_values
@@ -938,11 +1031,14 @@ class Sim(cvb.BaseSim):
 
                 # Sources are easy -- count up the arrays for all the people who became infections on that day
                 if method == 'infectious':
-                    inds = cvu.true(t == self.people.date_infectious) # Find people who became infectious on this timestep
+                    # Find people who became infectious on this timestep
+                    inds = cvu.true(t == self.people.date_infectious)
                 elif method == 'outcome':
-                    recov_inds = cvu.true(t == self.people.date_recovered) # Find people who recovered on this timestep
-                    dead_inds  = cvu.true(t == self.people.date_dead)  # Find people who died on this timestep
-                    inds       = np.concatenate((recov_inds, dead_inds))
+                    # Find people who recovered on this timestep
+                    recov_inds = cvu.true(t == self.people.date_recovered)
+                    # Find people who died on this timestep
+                    dead_inds = cvu.true(t == self.people.date_dead)
+                    inds = np.concatenate((recov_inds, dead_inds))
                 sources[t] = len(inds)
 
                 # Create the mapping from sources to dates
@@ -952,7 +1048,8 @@ class Sim(cvb.BaseSim):
             # Targets are hard -- loop over the transmission tree
             for transdict in self.people.infection_log:
                 source = transdict['source']
-                if source is not None and source in source_dates: # Skip seed infections and people with e.g. recovery after the end of the sim
+                # Skip seed infections and people with e.g. recovery after the end of the sim
+                if source is not None and source in source_dates:
                     source_date = source_dates[source]
                     targets[source_date] += 1
 
@@ -960,17 +1057,19 @@ class Sim(cvb.BaseSim):
                 #     targets[t] += len(self.people.transtree.targets[ind])
 
             # Populate the array -- to avoid divide-by-zero, skip indices that are 0
-            r_eff = np.divide(targets, sources, out=np.full(self.npts, np.nan), where=sources > 0)
+            r_eff = np.divide(targets, sources, out=np.full(
+                self.npts, np.nan), where=sources > 0)
 
             # Use stored weights calculate the moving average over the window of timesteps, n
             num = np.nancumsum(r_eff * sources)
             num[window:] = num[window:] - num[:-window]
             den = np.cumsum(sources)
             den[window:] = den[window:] - den[:-window]
-            values = np.divide(num, den, out=np.full(self.npts, np.nan), where=den > 0)
+            values = np.divide(num, den, out=np.full(
+                self.npts, np.nan), where=den > 0)
 
         # Method not recognized
-        else: # pragma: no cover
+        else:  # pragma: no cover
             errormsg = f'Method must be "daily", "infectious", or "outcome", not "{method}"'
             raise ValueError(errormsg)
 
@@ -978,7 +1077,6 @@ class Sim(cvb.BaseSim):
         self.results['r_eff'].values[:] = values
 
         return self.results['r_eff'].values
-
 
     def compute_gen_time(self):
         '''
@@ -1001,19 +1099,20 @@ class Sim(cvb.BaseSim):
             if infection['source'] is not None:
                 source_ind = infection['source']
                 target_ind = infection['target']
-                intervals1[pos1] = date_exposed[target_ind] - date_exposed[source_ind]
+                intervals1[pos1] = date_exposed[target_ind] - \
+                    date_exposed[source_ind]
                 pos1 += 1
                 if np.isfinite(date_symptomatic[source_ind]) and np.isfinite(date_symptomatic[target_ind]):
-                    intervals2[pos2] = date_symptomatic[target_ind] - date_symptomatic[source_ind]
+                    intervals2[pos2] = date_symptomatic[target_ind] - \
+                        date_symptomatic[source_ind]
                     pos2 += 1
 
         self.results['gen_time'] = {
-                'true':         np.mean(intervals1[:pos1]),
-                'true_std':     np.std(intervals1[:pos1]),
-                'clinical':     np.mean(intervals2[:pos2]),
-                'clinical_std': np.std(intervals2[:pos2])}
+            'true':         np.mean(intervals1[:pos1]),
+            'true_std':     np.std(intervals1[:pos1]),
+            'clinical':     np.mean(intervals2[:pos2]),
+            'clinical_std': np.std(intervals2[:pos2])}
         return self.results['gen_time']
-
 
     def compute_summary(self, full=None, t=None, update=True, output=False, require_run=False):
         '''
@@ -1049,7 +1148,6 @@ class Sim(cvb.BaseSim):
         else:
             return
 
-
     def summarize(self, full=False, t=None, output=False):
         '''
         Print a medium-length summary of the simulation, drawing from the last time
@@ -1069,7 +1167,8 @@ class Sim(cvb.BaseSim):
             sim.summarize(t=24, full=True) # Print a "slice" of all sim results on day 24
         '''
         # Compute the summary
-        summary = self.compute_summary(full=full, t=t, update=False, output=True)
+        summary = self.compute_summary(
+            full=full, t=t, update=False, output=True)
 
         # Construct the output string
         labelstr = f' "{self.label}"' if self.label else ''
@@ -1083,7 +1182,6 @@ class Sim(cvb.BaseSim):
             print(string)
         else:
             return string
-
 
     def disp(self, output=False):
         '''
@@ -1104,7 +1202,6 @@ class Sim(cvb.BaseSim):
             print(string)
         else:
             return string
-
 
     def brief(self, output=False):
         '''
@@ -1127,7 +1224,6 @@ class Sim(cvb.BaseSim):
         else:
             return string
 
-
     def compute_fit(self, *args, **kwargs):
         '''
         Compute the fit between the model and the data. See cv.Fit() for more
@@ -1149,7 +1245,6 @@ class Sim(cvb.BaseSim):
         '''
         self.fit = cva.Fit(self, *args, **kwargs)
         return self.fit
-
 
     def calibrate(self, calib_pars, **kwargs):
         '''
@@ -1174,7 +1269,6 @@ class Sim(cvb.BaseSim):
         calib.calibrate()
         return calib
 
-
     def make_age_histogram(self, *args, output=True, **kwargs):
         '''
         Calculate the age histograms of infections, deaths, diagnoses, etc. See
@@ -1198,10 +1292,9 @@ class Sim(cvb.BaseSim):
         agehist = cva.age_histogram(sim=self, *args, **kwargs)
         if output:
             return agehist
-        else: # pragma: no cover
+        else:  # pragma: no cover
             self.results.agehist = agehist
             return
-
 
     def make_transtree(self, *args, output=True, **kwargs):
         '''
@@ -1222,10 +1315,9 @@ class Sim(cvb.BaseSim):
         tt = cva.TransTree(self, *args, **kwargs)
         if output:
             return tt
-        else: # pragma: no cover
+        else:  # pragma: no cover
             self.results.transtree = tt
             return
-
 
     def plot(self, *args, **kwargs):
         '''
@@ -1284,7 +1376,6 @@ class Sim(cvb.BaseSim):
         fig = cvplt.plot_sim(sim=self, *args, **kwargs)
         return fig
 
-
     def plot_result(self, key, *args, **kwargs):
         '''
         Simple method to plot a single result. Useful for results that aren't
@@ -1328,11 +1419,13 @@ def diff_sims(sim1, sim2, skip_key_diffs=False, output=False, die=False):
     '''
 
     if isinstance(sim1, Sim):
-        sim1 = sim1.compute_summary(update=False, output=True, require_run=True)
+        sim1 = sim1.compute_summary(
+            update=False, output=True, require_run=True)
     if isinstance(sim2, Sim):
-        sim2 = sim2.compute_summary(update=False, output=True, require_run=True)
+        sim2 = sim2.compute_summary(
+            update=False, output=True, require_run=True)
     for sim in [sim1, sim2]:
-        if not isinstance(sim, dict): # pragma: no cover
+        if not isinstance(sim, dict):  # pragma: no cover
             errormsg = f'Cannot compare object of type {type(sim)}, must be a sim or a sim.summary dict'
             raise TypeError(errormsg)
 
@@ -1340,10 +1433,10 @@ def diff_sims(sim1, sim2, skip_key_diffs=False, output=False, die=False):
     keymatchmsg = ''
     sim1_keys = set(sim1.keys())
     sim2_keys = set(sim2.keys())
-    if sim1_keys != sim2_keys and not skip_key_diffs: # pragma: no cover
+    if sim1_keys != sim2_keys and not skip_key_diffs:  # pragma: no cover
         keymatchmsg = "Keys don't match!\n"
         missing = list(sim1_keys - sim2_keys)
-        extra   = list(sim2_keys - sim1_keys)
+        extra = list(sim2_keys - sim1_keys)
         if missing:
             keymatchmsg += f'  Missing sim1 keys: {missing}\n'
         if extra:
@@ -1352,32 +1445,33 @@ def diff_sims(sim1, sim2, skip_key_diffs=False, output=False, die=False):
     # Compare values
     valmatchmsg = ''
     mismatches = {}
-    for key in sim2.keys(): # To ensure order
-        if key in sim1_keys: # If a key is missing, don't count it as a mismatch
+    for key in sim2.keys():  # To ensure order
+        if key in sim1_keys:  # If a key is missing, don't count it as a mismatch
             sim1_val = sim1[key] if key in sim1 else 'not present'
             sim2_val = sim2[key] if key in sim2 else 'not present'
-            both_nan = sc.isnumber(sim1_val, isnan=True) and sc.isnumber(sim2_val, isnan=True)
+            both_nan = sc.isnumber(sim1_val, isnan=True) and sc.isnumber(
+                sim2_val, isnan=True)
             if sim1_val != sim2_val and not both_nan:
                 mismatches[key] = {'sim1': sim1_val, 'sim2': sim2_val}
 
     if len(mismatches):
         valmatchmsg = '\nThe following values differ between the two simulations:\n'
         df = pd.DataFrame.from_dict(mismatches).transpose()
-        diff   = []
-        ratio  = []
+        diff = []
+        ratio = []
         change = []
-        small_change = 1e-3 # Define a small change, e.g. a rounding error
+        small_change = 1e-3  # Define a small change, e.g. a rounding error
         for mdict in mismatches.values():
             old = mdict['sim1']
             new = mdict['sim2']
             numeric = sc.isnumber(sim1_val) and sc.isnumber(sim2_val)
-            if numeric and old>0:
-                this_diff  = new - old
+            if numeric and old > 0:
+                this_diff = new - old
                 this_ratio = new/old
-                abs_ratio  = max(this_ratio, 1.0/this_ratio)
+                abs_ratio = max(this_ratio, 1.0/this_ratio)
 
                 # Set the character to use
-                if abs_ratio<small_change:
+                if abs_ratio < small_change:
                     change_char = '≈'
                 elif new > old:
                     change_char = '↑'
@@ -1397,9 +1491,9 @@ def diff_sims(sim1, sim2, skip_key_diffs=False, output=False, die=False):
                     repeats = 4
 
                 this_change = change_char*repeats
-            else: # pragma: no cover
-                this_diff   = np.nan
-                this_ratio  = np.nan
+            else:  # pragma: no cover
+                this_diff = np.nan
+                this_ratio = np.nan
                 this_change = 'N/A'
 
             diff.append(this_diff)
@@ -1415,7 +1509,7 @@ def diff_sims(sim1, sim2, skip_key_diffs=False, output=False, die=False):
 
     # Raise an error if mismatches were found
     mismatchmsg = keymatchmsg + valmatchmsg
-    if mismatchmsg: # pragma: no cover
+    if mismatchmsg:  # pragma: no cover
         if die:
             raise ValueError(mismatchmsg)
         elif output:
@@ -1453,7 +1547,7 @@ def demo(preset=None, to_plot=None, scens=None, run_args=None, plot_args=None, *
     run_args = sc.mergedicts(run_args)
     plot_args = sc.mergedicts(plot_args)
     if to_plot:
-        plot_args = sc.mergedicts(plot_args, {'to_plot':to_plot})
+        plot_args = sc.mergedicts(plot_args, {'to_plot': to_plot})
 
     if not preset:
         sim = Sim(**kwargs)
@@ -1463,35 +1557,40 @@ def demo(preset=None, to_plot=None, scens=None, run_args=None, plot_args=None, *
 
     elif preset == 'full':
 
-            # Define interventions
-            cb = cvi.change_beta(days=40, changes=0.5)
-            tp = cvi.test_prob(start_day=20, symp_prob=0.1, asymp_prob=0.01)
-            ct = cvi.contact_tracing(trace_probs=0.3, start_day=50)
+        # Define interventions
+        cb = cvi.change_beta(days=40, changes=0.5)
+        tp = cvi.test_prob(start_day=20, symp_prob=0.1, asymp_prob=0.01)
+        ct = cvi.contact_tracing(trace_probs=0.3, start_day=50)
 
-            # Define the parameters
-            pars = dict(
-                pop_size      = 20e3,         # Population size
-                pop_infected  = 100,          # Number of initial infections -- use more for increased robustness
-                pop_type      = 'hybrid',     # Population to use -- "hybrid" is random with household, school,and work structure
-                n_days        = 60,           # Number of days to simulate
-                verbose       = 0,            # Don't print details of the run
-                rand_seed     = 2,            # Set a non-default seed
-                interventions = [cb, tp, ct], # Include the most common interventions
-            )
-            pars = sc.mergedicts(pars, kwargs)
-            if scens is None:
-                scens = ('beta', {'Low beta':0.012, 'Medium beta':0.016, 'High beta':0.020})
-            scenpar = scens[0]
-            scenval = scens[1]
+        # Define the parameters
+        pars = dict(
+            pop_size=20e3,         # Population size
+            # Number of initial infections -- use more for increased robustness
+            pop_infected=100,
+            # Population to use -- "hybrid" is random with household, school,and work structure
+            pop_type='hybrid',
+            n_days=60,           # Number of days to simulate
+            verbose=0,            # Don't print details of the run
+            rand_seed=2,            # Set a non-default seed
+            # Include the most common interventions
+            interventions=[cb, tp, ct],
+        )
+        pars = sc.mergedicts(pars, kwargs)
+        if scens is None:
+            scens = ('beta', {'Low beta': 0.012,
+                     'Medium beta': 0.016, 'High beta': 0.020})
+        scenpar = scens[0]
+        scenval = scens[1]
 
-            # Run the simulations
-            sims = [Sim(pars, **{scenpar:val}, label=label) for label,val in scenval.items()]
-            msim = cvr.MultiSim(sims)
-            msim.run(**run_args)
-            msim.plot(**plot_args)
-            msim.median()
-            msim.plot(**plot_args)
-            return msim
+        # Run the simulations
+        sims = [Sim(pars, **{scenpar: val}, label=label)
+                for label, val in scenval.items()]
+        msim = cvr.MultiSim(sims)
+        msim.run(**run_args)
+        msim.plot(**plot_args)
+        msim.median()
+        msim.plot(**plot_args)
+        return msim
 
     else:
         errormsg = f'Could not understand preset argument "{preset}"; must be None or "full"'


### PR DESCRIPTION
Applying Aggregate Design Pattern to population.py

Background
I made this change to apply the aggerate pattern in the open-source project we chose in the lab. And the goal of this lab is to find the place that can apply aggeration. Therefore we are asked to make 2 pull request

Abstract
When I design the domain diagram for this project. I have the population domain in my design. But the in population.py only contained several functions like make_people, make_randpop, and functions to deal with contacts, etc. However, the functions were not grouped well together. This creates obscurity in the code and makes it hard to read. Hence, I created two new classes population as root aggregate and contact to aggregate their respective operations.

Explanation
The population module contained several functions that operate on certain data types, which were not aggregated together. For example, all the make_* functions are used to initialized the people objects, and random population. These functions help construct data on states, so we can aggregate them into a population class to make the code easier to read and understand.