### PR TITLE
Applying Aggregate to run.py 01

### DIFF
--- a/covasim/run.py
+++ b/covasim/run.py
@@ -32,6 +32,67 @@ def make_metapars():
     )
     return metapars
 
+    def init_sims(self, **kwargs):
+        '''
+        Initialize the sims, but don't actually run them. Syntax is the same
+        as MultiSim.run(). Note: in most cases you can just call run() directly,
+        there is no need to call this separately.
+
+        Args:
+            kwargs  (dict): passed to multi_run()
+        '''
+
+        # Handle which sims to use
+        if self.sims is None:
+            sims = self.base_sim
+        else:
+            sims = self.sims
+
+        # Initialize the sims but don't run them
+        kwargs = sc.mergedicts(self.run_args, kwargs, {'do_run':False}) # Never run, that's the point!
+        self.sims = multi_run(sims, **kwargs)
+
+        return
+
+
+    def run(self, reduce=False, combine=False, **kwargs):
+        '''
+        Run the actual sims
+
+        Args:
+            reduce  (bool): whether or not to reduce after running (see reduce())
+            combine (bool): whether or not to combine after running (see combine(), not compatible with reduce)
+            kwargs  (dict): passed to multi_run(); use run_args to pass arguments to sim.run()
+
+        Returns:
+            None (modifies MultiSim object in place)
+
+        **Examples**::
+
+            msim.run()
+            msim.run(run_args=dict(until='2020-0601', restore_pars=False))
+        '''
+        # Handle which sims to use -- same as init_sims()
+        if self.sims is None:
+            sims = self.base_sim
+        else:
+            sims = self.sims
+
+        # Run
+        kwargs = sc.mergedicts(self.run_args, kwargs)
+        self.sims = multi_run(sims, **kwargs)
+
+        # Reduce or combine
+        if reduce:
+            self.reduce()
+        elif combine:
+            self.combine()
+
+        return self
+
+
+
+
 
 class MultiSim(cvb.FlexPretty):
     '''
@@ -115,64 +176,6 @@ class MultiSim(cvb.FlexPretty):
             raise ValueError(errormsg)
         return keys
 
-
-    def init_sims(self, **kwargs):
-        '''
-        Initialize the sims, but don't actually run them. Syntax is the same
-        as MultiSim.run(). Note: in most cases you can just call run() directly,
-        there is no need to call this separately.
-
-        Args:
-            kwargs  (dict): passed to multi_run()
-        '''
-
-        # Handle which sims to use
-        if self.sims is None:
-            sims = self.base_sim
-        else:
-            sims = self.sims
-
-        # Initialize the sims but don't run them
-        kwargs = sc.mergedicts(self.run_args, kwargs, {'do_run':False}) # Never run, that's the point!
-        self.sims = multi_run(sims, **kwargs)
-
-        return
-
-
-    def run(self, reduce=False, combine=False, **kwargs):
-        '''
-        Run the actual sims
-
-        Args:
-            reduce  (bool): whether or not to reduce after running (see reduce())
-            combine (bool): whether or not to combine after running (see combine(), not compatible with reduce)
-            kwargs  (dict): passed to multi_run(); use run_args to pass arguments to sim.run()
-
-        Returns:
-            None (modifies MultiSim object in place)
-
-        **Examples**::
-
-            msim.run()
-            msim.run(run_args=dict(until='2020-0601', restore_pars=False))
-        '''
-        # Handle which sims to use -- same as init_sims()
-        if self.sims is None:
-            sims = self.base_sim
-        else:
-            sims = self.sims
-
-        # Run
-        kwargs = sc.mergedicts(self.run_args, kwargs)
-        self.sims = multi_run(sims, **kwargs)
-
-        # Reduce or combine
-        if reduce:
-            self.reduce()
-        elif combine:
-            self.combine()
-
-        return self
 
 
     def _has_orig_sim(self):


### PR DESCRIPTION
### Please note that this change is for a school project on Applying Aggregates. So please bear with me.

The problem that I noticed is that there is no clear design in run.py to make sure that the design follows a consistent valid state for each iteration. Therefore I implemented an aggregate to make sure that run.py follows a valid state before moving on to the caller methods.