### PR TITLE
Add state pattern to base.py

### DIFF
--- a/covasim/analysis.py
+++ b/covasim/analysis.py
@@ -939,7 +939,7 @@ class Fit(Analyzer):
         self.data = sim.data
 
         # Copy sim results
-        if not sim.results_ready: # pragma: no cover
+        if not sim.results_ready(): # pragma: no cover
             errormsg = 'Model fit cannot be calculated until results are run'
             if self.die:
                 raise RuntimeError(errormsg)

--- a/covasim/misc.py
+++ b/covasim/misc.py
@@ -595,7 +595,7 @@ def get_doubling_time(sim, series=None, interval=None, start_day=None, end_day=N
 
     # Validate inputs: series
     if series is None or isinstance(series, str):
-        if not sim.results_ready: # pragma: no cover
+        if not sim.results_ready(): # pragma: no cover
             raise Exception("Results not ready, cannot calculate doubling time")
         else:
             if series is None or series not in sim.result_keys():

--- a/covasim/plotting.py
+++ b/covasim/plotting.py
@@ -88,7 +88,7 @@ def handle_to_plot(kind, to_plot, n_cols, sim, check_ready=True):
     ''' Handle which quantities to plot '''
 
     # Check that results are ready
-    if check_ready and not sim.results_ready:
+    if check_ready and not sim.results_ready():
         errormsg = 'Cannot plot since results are not ready yet -- did you run the sim?'
         raise RuntimeError(errormsg)
 

--- a/covasim/run.py
+++ b/covasim/run.py
@@ -839,17 +839,11 @@ class MultiSim(cvb.FlexPretty):
 
     def to_json(self, *args, **kwargs):
         ''' Shortcut for base_sim.to_json() '''
-        if not self.base_sim.results_ready: # pragma: no cover
-            errormsg = 'JSON export only available for reduced sim; please run msim.mean() or msim.median() first'
-            raise RuntimeError(errormsg)
         return self.base_sim.to_json(*args, **kwargs)
 
 
     def to_excel(self, *args, **kwargs):
         ''' Shortcut for base_sim.to_excel() '''
-        if not self.base_sim.results_ready: # pragma: no cover
-            errormsg = 'Excel export only available for reduced sim; please run msim.mean() or msim.median() first'
-            raise RuntimeError(errormsg)
         return self.base_sim.to_excel(*args, **kwargs)
 
 


### PR DESCRIPTION
Define class ResultsState and children classes ResultsNotReadyState and ResultsReadyState
Change results_ready field of BaseSim to results_state, with results_ready() method in BaseSim
Only set results_state to either ResultsNotReadyState and ResultsReadyState
Delegate to_json and to_excel methods of BaseSim to those of results_state