### PR TITLE
removed deprecated system packages from RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ sphinx:
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:
-   - pdf
+
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Read the Docs is deprecating the "use system packages" option in the configuration file. I tested the build without that option and it passes because numpy and other system packages installed by RTD are already specified in requirements.txt. 

https://github.com/InstituteforDiseaseModeling/idm-content/issues/44