### PR TITLE
removed deprecated system_packages from rtd.yml:

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,4 +25,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true


### PR DESCRIPTION
Read the Docs is deprecating the system_packages key in the YAML config file. All package requirements must be listed in the requirements.txt/setup.py files instead (this was already the case for covasim). 